### PR TITLE
Register api

### DIFF
--- a/backend/app/controllers/api/auth/oauth_controller.rb
+++ b/backend/app/controllers/api/auth/oauth_controller.rb
@@ -14,6 +14,7 @@ module Api
 
         status = 200
         if @user.new_record?
+          @user.email = auth_params[:email].blank? ? "" : auth_params[:email]
           status = 201
 
           begin

--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -44,8 +44,9 @@ module Api
       rescue ActiveRecord::RecordNotFound
         error_res(404, message: 'ユーザが存在しません',err: 'ユーザが存在しません') and return
       rescue ActiveRecord::RecordInvalid => e
-        error_res(422, message: 'バリデーションエラー',err: e.record.errors) and return
-      rescue
+        error_res(422, message: '入力内容が正しくありません',err: e.record.errors) and return
+      rescue => e
+        logger.error(e)
         error_res(500, message: '更新に失敗しました',err: '更新に失敗しました') and return
       end
     end

--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -37,7 +37,14 @@ module Api
     end
 
     def update
-      render json: { message:"I'm update." }
+      @user = User.find(params:[:uid])
+      begin
+        @user.update!(email: params[:email])
+        success_res(200, message: 'Eメールを更新しました') and return
+      rescue => e
+        logger.error(e)
+        error_res(500, err: '更新に失敗しました') and return
+      end
     end
 
     def destroy

--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -37,12 +37,15 @@ module Api
     end
 
     def update
-      @user = User.find(params:[:uid])
       begin
+        @user = User.find(params[:id])
         @user.update!(email: params[:email])
         success_res(200, message: 'Eメールを更新しました') and return
-      rescue => e
-        logger.error(e)
+      rescue ActiveRecord::RecordNotFound
+        error_res(404, err: 'ユーザが存在しません') and return
+      rescue ActiveRecord::RecordInvalid => e
+        error_res(400, err: e.record.errors) and return
+      rescue
         error_res(500, err: '更新に失敗しました') and return
       end
     end

--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -42,11 +42,11 @@ module Api
         @user.update!(email: params[:email])
         success_res(200, message: 'Eメールを更新しました') and return
       rescue ActiveRecord::RecordNotFound
-        error_res(404, err: 'ユーザが存在しません') and return
+        error_res(404, message: 'ユーザが存在しません',err: 'ユーザが存在しません') and return
       rescue ActiveRecord::RecordInvalid => e
-        error_res(400, err: e.record.errors) and return
+        error_res(422, message: 'バリデーションエラー',err: e.record.errors) and return
       rescue
-        error_res(500, err: '更新に失敗しました') and return
+        error_res(500, message: '更新に失敗しました',err: '更新に失敗しました') and return
       end
     end
 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, uniqueness: true, allow_blank: true, format: { with: VALID_EMAIL_REGEX }
   enum gender:  { not_set: 0, man: 1, woman: 2, other: 3}, _prefix: true
   enum figure:  {
                   not_set: 0,

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  validates :email, uniqueness: true, allow_blank: true, format: { with: VALID_EMAIL_REGEX }
+  validates :email, uniqueness: true, allow_blank: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   enum gender:  { not_set: 0, man: 1, woman: 2, other: 3}, _prefix: true
   enum figure:  {
                   not_set: 0,

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -19,3 +19,10 @@ ja:
         not_set: "未設定"
         gachi:   "ガチ"
         enjoy:   "エンジョイ"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              invalid: "Eメールの形式で入力してください"

--- a/docs/api_blueprint.md
+++ b/docs/api_blueprint.md
@@ -253,6 +253,26 @@ Muscler'sのAPI仕様書
       ],
   }
 
+### ユーザ情報更新 [PATCH]
+
++ Response 200
+
+    + Attributes (object)
+        + status: 200 (number)
+        + message: Eメールを更新しました (string)
+
++ Response 500
+
+    + Attributes (object)
+        + status: 500 (number)
+        + message: 更新に失敗しました (string)
+
+## Users [/api/users/{user_id}]
+
++ Parameters
+
+    + email: huga@hoge.com (string) - ユーザのEメール
+
 # Group INFORMATIONS
 
 ## Informations [/api/users/{user_id}/informations]

--- a/docs/api_blueprint.md
+++ b/docs/api_blueprint.md
@@ -253,6 +253,12 @@ Muscler'sのAPI仕様書
       ],
   }
 
+## Users [/api/users/{user_id}]
+
++ Parameters
+
+    + email: huga@hoge.com (string) - ユーザのEメール
+
 ### ユーザ情報更新 [PATCH]
 
 + Response 200
@@ -261,17 +267,35 @@ Muscler'sのAPI仕様書
         + status: 200 (number)
         + message: Eメールを更新しました (string)
 
++ Response 404
+
+  {
+      "status": 404,
+      "message": "ユーザが存在しません"
+      "errors": [
+        { message: "ユーザが存在しません" }
+      ],
+  }
+
++ Response 422
+
+  {
+      "status": 422,
+      "message": "バリデーションエラー"
+      "errors": [
+        { message: { email:"Eメールの形式で入力してください" } }
+      ],
+  }
+
 + Response 500
 
-    + Attributes (object)
-        + status: 500 (number)
-        + message: 更新に失敗しました (string)
-
-## Users [/api/users/{user_id}]
-
-+ Parameters
-
-    + email: huga@hoge.com (string) - ユーザのEメール
+  {
+      "status": 500,
+      "message": "更新に失敗しました"
+      "errors": [
+        { message: "更新に失敗しました" }
+      ],
+  }
 
 # Group INFORMATIONS
 

--- a/docs/api_blueprint.md
+++ b/docs/api_blueprint.md
@@ -228,6 +228,51 @@ Muscler'sのAPI仕様書
       ],
   }
 
+### ユーザ情報更新 [PATCH]
++ Headers
+    Authorization: ...
+
++ Request (application/json)
+
+    + Attributes (object)
+        + email: sample@example.com (string)
+
++ Response 200
+
+    + Attributes (object)
+        + status: 200 (number)
+        + message: Eメールを更新しました (string)
+
++ Response 404
+
+  {
+      "status": 404,
+      "message": "ユーザが存在しません"
+      "errors": [
+        { message: "ユーザが存在しません" }
+      ],
+  }
+
++ Response 422
+
+  {
+      "status": 422,
+      "message": "入力内容が正しくありません"
+      "errors": [
+        { message: { email:"Eメールの形式で入力してください" } }
+      ],
+  }
+
++ Response 500
+
+  {
+      "status": 500,
+      "message": "更新に失敗しました"
+      "errors": [
+        { message: "更新に失敗しました" }
+      ],
+  }
+
 ## Users [/api/users/search?nickname={nickname}]
 
 + Parameters
@@ -250,50 +295,6 @@ Muscler'sのAPI仕様書
       "message": "お探しのユーザは見つかりませんでした・"
       "errors": [
         { message: "お探しのユーザが見つかりませんでした。" }
-      ],
-  }
-
-## Users [/api/users/{user_id}]
-
-+ Parameters
-
-    + email: huga@hoge.com (string) - ユーザのEメール
-
-### ユーザ情報更新 [PATCH]
-
-+ Response 200
-
-    + Attributes (object)
-        + status: 200 (number)
-        + message: Eメールを更新しました (string)
-
-+ Response 404
-
-  {
-      "status": 404,
-      "message": "ユーザが存在しません"
-      "errors": [
-        { message: "ユーザが存在しません" }
-      ],
-  }
-
-+ Response 422
-
-  {
-      "status": 422,
-      "message": "バリデーションエラー"
-      "errors": [
-        { message: { email:"Eメールの形式で入力してください" } }
-      ],
-  }
-
-+ Response 500
-
-  {
-      "status": 500,
-      "message": "更新に失敗しました"
-      "errors": [
-        { message: "更新に失敗しました" }
       ],
   }
 

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -48,7 +48,8 @@ export default {
       src: '~plugins/persistedstate.js',
       ssr: false
     },
-    '~/plugins/axios.js'
+    '~/plugins/axios.js',
+    '~/plugins/vuelidate.js'
   ],
   /*
    ** Nuxt.js dev-modules

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -122,7 +122,7 @@ export default {
       login: '/',
       logout: '/',
       callback: '/callback',
-      home: '/'
+      home: '/redirect'
     },
     strategies: {
       facebook: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11078,6 +11078,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
+    "vuelidate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.4.tgz",
+      "integrity": "sha512-QHZWYOL325Zo+2K7VBNEJTZ496Kd8Z31p85aQJFldKudUUGBmgw4zu4ghl4CyqPwjRCmqZ9lDdx4FSdMnu4fGg=="
+    },
     "vuetify": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.0.17.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@nuxtjs/vuetify": "^1.8.3",
     "axios": "^0.19.0",
     "nuxt": "^2.0.0",
+    "vuelidate": "^0.7.4",
     "vuex-persistedstate": "^2.5.4"
   },
   "devDependencies": {

--- a/frontend/pages/callback.vue
+++ b/frontend/pages/callback.vue
@@ -22,7 +22,7 @@ export default {
 
     try {
       const res = await this.$axios.$post('/api/auth/sign_in', postData)
-      await this.$store.commit('auth/setCurrentUser', { user: res.data })
+      await this.$store.dispatch('auth/setCurrentUser', { user: res.data })
       if (res.data.email !== '') {
         this.$router.push('/users')
       } else {

--- a/frontend/pages/callback.vue
+++ b/frontend/pages/callback.vue
@@ -6,10 +6,13 @@
 export default {
   async mounted() {
     const state = this.$auth.$state
+
+    /*
     if (!state.user) {
       console.error('認証できませんでした')
       return this.$router.push('/auth/login')
     }
+    */
 
     const postData = {
       uid: state.user.id,
@@ -19,7 +22,7 @@ export default {
 
     try {
       const res = await this.$axios.$post('/api/auth/sign_in', postData)
-      await this.$store.dispatch('auth/setCurrentUser', { user: res.data })
+      await this.$store.commit('auth/setCurrentUser', { user: res.data })
       if (res.data.email !== '') {
         this.$router.push('/users')
       } else {

--- a/frontend/pages/callback.vue
+++ b/frontend/pages/callback.vue
@@ -1,33 +1,3 @@
 <template>
   <div>ログインしています......</div>
 </template>
-
-<script>
-export default {
-  async mounted() {
-    const state = this.$auth.$state
-    if (!state.user) {
-      console.error('認証できませんでした')
-      return this.$router.push('/auth/login')
-    }
-
-    const postData = {
-      uid: state.user.id,
-      provider: state.strategy,
-      email: state.user.email
-    }
-
-    try {
-      const res = await this.$axios.$post('/api/auth/sign_in', postData)
-      await this.$store.dispatch('auth/setCurrentUser', { user: res.data })
-      if (res.data.email !== '') {
-        this.$router.push('/users')
-      } else {
-        this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
-      }
-    } catch (err) {
-      console.error(err)
-    }
-  }
-}
-</script>

--- a/frontend/pages/callback.vue
+++ b/frontend/pages/callback.vue
@@ -18,17 +18,20 @@ export default {
     }
 
     try {
-      const res = await this.$axios.$post('/api/auth/sign_in', postData)
       console.log('debug1')
-      await this.$store.dispatch('auth/setCurrentUser', { user: res.data })
+      const res = await this.$axios.$post('/api/auth/sign_in', postData)
       console.log('debug2')
-      if (!res.data.email) {
-        console.log('debug3')
-        this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
-      } else {
+      await this.$store.dispatch('auth/setCurrentUser', { user: res.data })
+      console.log('debug3')
+      if (res.data.email) {
+        console.log('debug4')
         this.$router.push('/users')
+      } else {
+        console.log('debug5')
+        this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
       }
     } catch (err) {
+      console.log('debug6')
       console.error(err)
     }
   }

--- a/frontend/pages/callback.vue
+++ b/frontend/pages/callback.vue
@@ -18,20 +18,14 @@ export default {
     }
 
     try {
-      console.log('debug1')
       const res = await this.$axios.$post('/api/auth/sign_in', postData)
-      console.log('debug2')
       await this.$store.dispatch('auth/setCurrentUser', { user: res.data })
-      console.log('debug3')
-      if (res.data.email) {
-        console.log('debug4')
+      if (res.data.email !== '') {
         this.$router.push('/users')
       } else {
-        console.log('debug5')
         this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
       }
     } catch (err) {
-      console.log('debug6')
       console.error(err)
     }
   }

--- a/frontend/pages/callback.vue
+++ b/frontend/pages/callback.vue
@@ -19,12 +19,14 @@ export default {
 
     try {
       const res = await this.$axios.$post('/api/auth/sign_in', postData)
+      console.log('debug1')
       await this.$store.dispatch('auth/setCurrentUser', { user: res.data })
-
-      if (res.status === 200) {
+      console.log('debug2')
+      if (!res.data.email) {
+        console.log('debug3')
+        this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
+      } else {
         this.$router.push('/users')
-      } else if (res.status === 201) {
-        this.$router.push('/') // TODO: Email等の入力画面に遷移させる
       }
     } catch (err) {
       console.error(err)

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>home page</h1>
+  </div>
+</template>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -2,11 +2,5 @@
   <div>
     <h1>index page</h1>
     <nuxt-link to="/auth/login">ログイン</nuxt-link>
-    <button type="button" @click="login">login</button>
-    <button type="button" @click="logout">logout</button>
   </div>
 </template>
-
-<script>
-export default {}
-</script>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -3,9 +3,9 @@
     <h1>index page</h1>
     <nuxt-link to="/auth/login">ログイン</nuxt-link>
     <nuxt-link to="/register">登録</nuxt-link>
-    <button type="button" @click="login">login</button>
-    <button type="button" @click="logout">logout</button>
     <p>{{ $auth.$state }}</p>
+    {{ this.$store.state.auth.user }}
+    {{ this.$store.state.auth.currentUser }}
   </div>
 </template>
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -2,6 +2,7 @@
   <div>
     <h1>index page</h1>
     <nuxt-link to="/auth/login">ログイン</nuxt-link>
+    <nuxt-link to="/register">登録</nuxt-link>
     <button type="button" @click="login">login</button>
     <button type="button" @click="logout">logout</button>
     <p>{{ $auth.$state }}</p>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -2,10 +2,8 @@
   <div>
     <h1>index page</h1>
     <nuxt-link to="/auth/login">ログイン</nuxt-link>
-    <nuxt-link to="/register">登録</nuxt-link>
     <button type="button" @click="login">login</button>
     <button type="button" @click="logout">logout</button>
-    <p>{{ $auth.$state }}</p>
   </div>
 </template>
 

--- a/frontend/pages/redirect.vue
+++ b/frontend/pages/redirect.vue
@@ -19,15 +19,18 @@ export default {
       try {
         const res = await this.$axios.$post('/api/auth/sign_in', postData)
         this.$store.dispatch('auth/setCurrentUser', { user: res.data })
-        if (res.data.email !== '') {
-          this.$router.push('/home')
-        } else if (res.data.email === '' || res.data.email === null) {
-          this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
+        if (
+          res.data.email === '' ||
+          res.data.email === null ||
+          typeof res.data.email === 'undefined'
+        ) {
+          this.$router.push('/register')
         } else {
-          this.$router.push('/auth/login')
+          this.$router.push('/home')
         }
       } catch (err) {
         console.error(err)
+        this.$router.push('/auth/login')
       }
     }
   }

--- a/frontend/pages/redirect.vue
+++ b/frontend/pages/redirect.vue
@@ -20,9 +20,11 @@ export default {
         const res = await this.$axios.$post('/api/auth/sign_in', postData)
         this.$store.dispatch('auth/setCurrentUser', { user: res.data })
         if (res.data.email !== '') {
-          this.$router.push('/users')
-        } else {
+          this.$router.push('/home')
+        } else if (res.data.email === '' || res.data.email === null) {
           this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
+        } else {
+          this.$router.push('/auth/login')
         }
       } catch (err) {
         console.error(err)

--- a/frontend/pages/redirect.vue
+++ b/frontend/pages/redirect.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>ログインしています......</div>
+</template>
+
+<script>
+export default {
+  async mounted() {
+    const state = this.$auth.$state
+    if (!state.loggedIn) {
+      console.error('認証できませんでした')
+      return this.$router.push('/auth/login')
+    } else {
+      const postData = {
+        uid: state.user.id,
+        provider: state.strategy,
+        email: state.user.email
+      }
+
+      try {
+        const res = await this.$axios.$post('/api/auth/sign_in', postData)
+        this.$store.dispatch('auth/setCurrentUser', { user: res.data })
+        if (res.data.email !== '') {
+          this.$router.push('/users')
+        } else {
+          this.$router.push('/register') // TODO: Email等の入力画面に遷移させる
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+  }
+}
+</script>

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -1,39 +1,95 @@
 <template>
   <v-container>
     <v-col cols="12" sm="6" offset-sm="3">
-      <div>
+      <div class="text-center">
         <h3 class="margin">メールアドレスの設定</h3>
         <h5 class="red--text">
           Facebookでメールアドレスが設定されていませんでした。
         </h5>
+        <form>
+          <v-text-field
+            v-model="$v.email.$model"
+            :error-messages="emailErrors"
+            label="kobedenshi@gmail.com"
+            prepend-icon="email"
+            single-line
+            required
+            @input="$v.email.$touch()"
+            @blur="$v.email.$touch()"
+          />
+          <v-alert
+            v-if="validErrors.email"
+            border="right"
+            colored-border
+            type="error"
+            elevation="2"
+          >
+            {{ validErrors.email }}
+          </v-alert>
+          <v-btn class="primary" rounded @click="submit">submit</v-btn>
+          <h5 v-if="errMsg" class="red--text">{{ errMsg }}</h5>
+        </form>
       </div>
-      <form>
-        <v-text-field
-          v-model="email"
-          label="kobedenshi@gmail.com"
-          hide-details
-          prepend-icon="email"
-          single-line
-          required
-        />
-      </form>
     </v-col>
   </v-container>
 </template>
 <script>
+import { required, email } from 'vuelidate/lib/validators'
 export default {
-  data() {
-    return {
-      email: ''
+  validations: {
+    email: { required, email }
+  },
+
+  data: () => ({
+    email: '',
+    errMsg: null,
+    validErrors: {
+      email: null
+    }
+  }),
+
+  computed: {
+    emailErrors() {
+      const errors = []
+      if (!this.$v.email.$dirty) return errors
+      !this.$v.email.email &&
+        errors.push('メールアドレスの形式で入力してください')
+      !this.$v.email.required && errors.push('メールアドレスを入力してください')
+      return errors
+    }
+  },
+
+  methods: {
+    async submit() {
+      this.$v.$touch()
+      if (this.$v.$invalid) {
+        this.errMsg = '未入力の項目があります'
+      } else {
+        const user = this.$store.getters['auth/currentUser']
+        const postData = {
+          id: user.id,
+          email: this.email
+        }
+        try {
+          await this.$axios.$patch('/api/users/' + postData.id, postData)
+          this.$router.push('/sign_up')
+        } catch (err) {
+          if (!err.response.status) {
+            this.$router.push('/')
+          } else if (err.response.status === 400) {
+            this.validErrors.email = err.response.data.errors.message
+          } else {
+            this.$router.push('/')
+          }
+        }
+      }
     }
   }
 }
 </script>
+
 <style>
 .margin {
   margin: 120px 0px 0px 0px;
-}
-.margin-bottom {
-  margin-bottom: 50px;
 }
 </style>

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -76,7 +76,7 @@ export default {
         } catch (err) {
           if (!err.response.status) {
             this.$router.push('/')
-          } else if (err.response.status === 400) {
+          } else if (err.response.status === 422) {
             this.validErrors.email = err.response.data.errors.message
           } else {
             this.$router.push('/')

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -1,26 +1,34 @@
 <template>
-  <div class="text-center">
-    <h3 class="margin">メールアドレスの設定</h3>
-    <h5 class="red--text">
-      Facebookでメールアドレスが設定されていませんでした。
-    </h5>
-    <v-container>
-      <v-col cols="12" sm="6" offset-sm="3">
+  <v-container>
+    <v-col cols="12" sm="6" offset-sm="3">
+      <div>
+        <h3 class="margin">メールアドレスの設定</h3>
+        <h5 class="red--text">
+          Facebookでメールアドレスが設定されていませんでした。
+        </h5>
+      </div>
+      <form>
         <v-text-field
+          v-model="email"
           label="kobedenshi@gmail.com"
           hide-details
           prepend-icon="email"
           single-line
+          required
         />
-      </v-col>
-    </v-container>
-    <div class="margin-bottom">
-      <nuxt-link to="/sign_up">
-        <v-btn class="primary" rounded>登録 </v-btn>
-      </nuxt-link>
-    </div>
-  </div>
+      </form>
+    </v-col>
+  </v-container>
 </template>
+<script>
+export default {
+  data() {
+    return {
+      email: ''
+    }
+  }
+}
+</script>
 <style>
 .margin {
   margin: 120px 0px 0px 0px;

--- a/frontend/plugins/vuelidate.js
+++ b/frontend/plugins/vuelidate.js
@@ -1,0 +1,3 @@
+import Vue from 'vue'
+import Vuelidate from 'vuelidate'
+Vue.use(Vuelidate)

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -11,6 +11,7 @@ export const getters = {
 export const mutations = {
   setCurrentUser(state, { user }) {
     state.currentUser = user
+    state.token = user.access_token
   },
   setToken(state, { token }) {
     state.token = token

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -11,7 +11,6 @@ export const getters = {
 export const mutations = {
   setCurrentUser(state, { user }) {
     state.currentUser = user
-    state.token = user.access_token
   },
   setToken(state, { token }) {
     state.token = token


### PR DESCRIPTION
やったこと
・フロントエンドとバックエンドでのバリデーションチェック
・新規登録画面からEメールを入力してユーザデータの更新ができるようになった
・APIドキュメントの更新

~できてないこと~
~Facebook認証をした後にEメールが入力されていなければ新規登録の画面に遷移してほしいのだがしてくれない~
~金曜日のレビューまでには問題を解決したい~

~`index.vue` に新規登録へのリンクを追加しており、新規登録の動作確認は一応できる~
画面遷移できないバグとログインできないバグは解決