### PR TITLE
Add user search detail

### DIFF
--- a/frontend/pages/users/index.vue
+++ b/frontend/pages/users/index.vue
@@ -79,6 +79,8 @@ export default {
   beforeRouteUpdate(to, from, next) {
     // 検索クエリを更新
     this.searchQuery = to.query.q
+    // TODO: 再取得
+    console.log('beforeRouteUpdate')
     next()
   },
 

--- a/frontend/store/users.js
+++ b/frontend/store/users.js
@@ -1,0 +1,22 @@
+export const state = () => ({
+  searchParameters: {
+    text: '',
+    page: 1,
+    seriousness: 0,
+    gender: 0,
+    figure: 0,
+    ageBetween: { min: null, max: null },
+    weightBetween: { min: null, max: null },
+    heightBetween: { min: null, max: null }
+  }
+})
+
+export const getters = {
+  searchParameters: (state) => state.searchParameters
+}
+
+export const mutations = {
+  setSearchParameters(state, { parameters }) {
+    state.searchParameters = { ...state.searchParameters, ...parameters }
+  }
+}


### PR DESCRIPTION
メモ

# 目的
詳細検索ページと簡易検索バーのどちらからでも同じ仕組みでユーザーの取得ができるようにする。
ユーザー一覧ページから検索クエリのみの変更時にもユーザーの再取得をする。

# 方法案

usersストアを作成し、検索パラメーターを一式保存しておく。
ユーザー一覧ページからAPIアクセスするときは常にそのストアにある検索パラメーターを使用する。
これによって検索パラメーターがグローバルに管理される為、どこからでも同じ方法でデータ取得の管理ができる。