### PR TITLE
検索やページネーション全てに対応したクエリパラメータ操作処理を実装

### DIFF
--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -11,7 +11,7 @@ module Api
       search_result_data = User.search_user_in(
         page: params[:page],
         per_page: per_page,
-        search_keyword: params[:q]
+        search_keyword: params[:keywords]
       )
 
       if search_result_data.blank?

--- a/frontend/layouts/TheHeader.vue
+++ b/frontend/layouts/TheHeader.vue
@@ -101,12 +101,14 @@ export default {
     ],
     searchQuery: ''
   }),
+
   computed: {
     ...mapGetters({
       currentUser: 'auth/currentUser',
       shapedSearchParameters: 'users/shapedSearchParameters'
     })
   },
+
   methods: {
     login() {
       this.$router.push('/auth/login')

--- a/frontend/layouts/TheHeader.vue
+++ b/frontend/layouts/TheHeader.vue
@@ -103,7 +103,8 @@ export default {
   }),
   computed: {
     ...mapGetters({
-      currentUser: 'auth/currentUser'
+      currentUser: 'auth/currentUser',
+      shapedSearchParameters: 'users/shapedSearchParameters'
     })
   },
   methods: {
@@ -115,7 +116,6 @@ export default {
       this.$store.dispatch('auth/logout')
     },
     handleSelectGroup(groupObj) {
-      console.log(groupObj)
       if (!groupObj) {
         return
       }
@@ -136,7 +136,12 @@ export default {
       }
     },
     onSubmitSearch() {
-      this.$router.push('/users?q=' + this.searchQuery)
+      const parameters = { keywords: this.searchQuery }
+      this.$store.commit('users/setSearchParameters', { parameters })
+      this.$router.push({
+        path: '/users',
+        query: this.shapedSearchParameters
+      })
     }
   }
 }

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -49,7 +49,8 @@ export default {
       ssr: false
     },
     '~/plugins/axios.js',
-    '~/plugins/vuelidate.js'
+    '~/plugins/vuelidate.js',
+    '~/plugins/queryParamsUpdater.js'
   ],
   /*
    ** Nuxt.js dev-modules

--- a/frontend/pages/users/index.vue
+++ b/frontend/pages/users/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1>ユーザー一覧</h1>
-    <p>「{{ searchQuery }}」で検索しました。</p>
+    <p>「{{ shapedSearchParameters.keywords }}」で検索しました。</p>
 
     <paginator :meta="meta" @click="updateUsersPage"></paginator>
 

--- a/frontend/pages/users/index.vue
+++ b/frontend/pages/users/index.vue
@@ -94,11 +94,15 @@ export default {
     })
   },
 
-  beforeRouteUpdate(to, from, next) {
-    // 検索クエリを更新
-    this.searchQuery = to.query.q
-    // TODO: 再取得
-    console.log('beforeRouteUpdate')
+  async beforeRouteUpdate(to, from, next) {
+    const res = await fetchSearchedUsers({
+      fetcher: this.$axios,
+      params: this.shapedSearchParameters
+    })
+    if (res.status === 200) {
+      this.users = res.data
+      this.meta = res.meta
+    }
     next()
   },
 

--- a/frontend/pages/users/index.vue
+++ b/frontend/pages/users/index.vue
@@ -67,6 +67,17 @@
 import { mapGetters } from 'vuex'
 import Paginator from '../../components/Paginator'
 
+function fetchSearchedUsers({ fetcher, params }) {
+  return fetcher.$get(`/api/users/search`, { params }).catch((err) => {
+    if (err && err.response && err.response.data) {
+      console.error('Reponse: ' + err.response.data.message)
+      return err.response
+    }
+
+    throw err
+  })
+}
+
 export default {
   components: {
     Paginator
@@ -94,18 +105,10 @@ export default {
   async asyncData({ $axios, query, error, store }) {
     const searchQuery = query.q
 
-    const res = await $axios
-      .$get('/api/users/search', {
-        params: store.getters['users/shapedSearchParameters']
-      })
-      .catch((err) => {
-        if (err && err.response && err.response.data) {
-          console.error('Reponse: ' + err.response.data.message)
-          return err.response
-        }
-
-        throw err
-      })
+    const res = await fetchSearchedUsers({
+      fetcher: $axios,
+      params: store.getters['users/shapedSearchParameters']
+    })
 
     if (res.status !== 200) {
       error({ statusCode: res.status, message: res.data.message })

--- a/frontend/pages/users/index.vue
+++ b/frontend/pages/users/index.vue
@@ -79,6 +79,8 @@ export default {
   beforeRouteUpdate(to, from, next) {
     // 検索クエリを更新
     this.searchQuery = to.query.q
+    // TODO: 再取得
+    console.log('beforeRouteUpdate')
     next()
   },
 

--- a/frontend/pages/users/index.vue
+++ b/frontend/pages/users/index.vue
@@ -64,6 +64,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import Paginator from '../../components/Paginator'
 
 export default {
@@ -76,6 +77,12 @@ export default {
     users: null
   }),
 
+  computed: {
+    ...mapGetters({
+      shapedSearchParameters: 'users/shapedSearchParameters'
+    })
+  },
+
   beforeRouteUpdate(to, from, next) {
     // 検索クエリを更新
     this.searchQuery = to.query.q
@@ -84,17 +91,21 @@ export default {
     next()
   },
 
-  async asyncData({ $axios, query, error }) {
+  async asyncData({ $axios, query, error, store }) {
     const searchQuery = query.q
 
-    const res = await $axios.$get('/api/users/search').catch((err) => {
-      if (err && err.response && err.response.data) {
-        console.error('Reponse: ' + err.response.data.message)
-        return err.response
-      }
+    const res = await $axios
+      .$get('/api/users/search', {
+        params: store.getters['users/shapedSearchParameters']
+      })
+      .catch((err) => {
+        if (err && err.response && err.response.data) {
+          console.error('Reponse: ' + err.response.data.message)
+          return err.response
+        }
 
-      throw err
-    })
+        throw err
+      })
 
     if (res.status !== 200) {
       error({ statusCode: res.status, message: res.data.message })
@@ -114,8 +125,11 @@ export default {
       console.log(userId)
     },
     async updateUsersPage(page) {
+      const parameters = { page }
+      this.$store.commit('users/addSearchParameters', { parameters })
+
       const res = await this.$axios
-        .$get(`/api/users/search?page=${page}`)
+        .$get(`/api/users/search`, { params: this.shapedSearchParameters })
         .catch((err) => {
           if (err && err.response && err.response.data) {
             console.error('Reponse: ' + err.response.data.message)

--- a/frontend/pages/users/index.vue
+++ b/frontend/pages/users/index.vue
@@ -131,25 +131,11 @@ export default {
       // TODO: 友達申請APIを呼び出す
       console.log(userId)
     },
-    async updateUsersPage(page) {
+    updateUsersPage(page) {
+      // pageの変更をURLのクエリパラメータに反映
       const parameters = { page }
       this.$store.commit('users/addSearchParameters', { parameters })
-
-      const res = await this.$axios
-        .$get(`/api/users/search`, { params: this.shapedSearchParameters })
-        .catch((err) => {
-          if (err && err.response && err.response.data) {
-            console.error('Reponse: ' + err.response.data.message)
-            return err.response
-          }
-
-          throw err
-        })
-
-      if (res.status === 200) {
-        this.users = res.data
-        this.meta = res.meta
-      }
+      this.$router.replace({ query: this.shapedSearchParameters })
     }
   }
 }

--- a/frontend/plugins/queryParamsUpdater.js
+++ b/frontend/plugins/queryParamsUpdater.js
@@ -1,9 +1,5 @@
 export default ({ app, store }) => {
   app.router.beforeEach((to, from, next) => {
-    console.log('------')
-    console.log(store.getters['users/shapedSearchParameters'])
-    console.log(to.query)
-    console.log('------')
     store.commit('users/setFilteredSearchParameters', { queries: to.query })
     next({ query: store.getters['users/shapedSearchParameters'] })
   })

--- a/frontend/plugins/queryParamsUpdater.js
+++ b/frontend/plugins/queryParamsUpdater.js
@@ -1,0 +1,10 @@
+export default ({ app, store }) => {
+  app.router.beforeEach((to, from, next) => {
+    console.log('------')
+    console.log(store.getters['users/shapedSearchParameters'])
+    console.log(to.query)
+    console.log('------')
+    store.commit('users/setFilteredSearchParameters', { queries: to.query })
+    next({ query: store.getters['users/shapedSearchParameters'] })
+  })
+}

--- a/frontend/store/users.js
+++ b/frontend/store/users.js
@@ -20,7 +20,7 @@ export const getters = {
     // 設定されたパラメータだけを抽出
     return Object.entries(state.searchParameters)
       .filter(([key, val]) => {
-        return val !== null
+        return val !== null && val !== ''
       })
       .reduce((result, current) => {
         result[current[0]] = current[1]

--- a/frontend/store/users.js
+++ b/frontend/store/users.js
@@ -33,6 +33,20 @@ export const getters = {
 
 export const mutations = {
   setSearchParameters(state, { parameters }) {
+    state.searchParameters = { ...defaultState.searchParameters, ...parameters }
+  },
+  addSearchParameters(state, { parameters }) {
     state.searchParameters = { ...state.searchParameters, ...parameters }
+  },
+  setFilteredSearchParameters(state, { queries }) {
+    const filteredQueries = Object.entries(queries)
+      .filter(([key, val]) => {
+        return state.searchParameters.hasOwnProperty(key)
+      })
+      .reduce((result, current) => {
+        result[current[0]] = current[1]
+        return result
+      }, {})
+    state.searchParameters = { ...state.searchParameters, ...filteredQueries }
   }
 }

--- a/frontend/store/users.js
+++ b/frontend/store/users.js
@@ -1,0 +1,22 @@
+export const state = () => ({
+  searchParameters: {
+    text: '',
+    page: 1,
+    seriousness: 0,
+    gender: 0,
+    figure: 0,
+    ageBetween: { min: null, max: null },
+    weightBetween: { min: null, max: null },
+    heightBetween: { min: null, max: null }
+  }
+})
+
+export const getters = {
+  searchParameters: (state) => state.searchParameters
+}
+
+export const mutations = {
+  setSearchParameters(state, { parameters }) {
+    state.searchParameters = { ...state.searchParameters, ...parameters }
+  }
+}

--- a/frontend/store/users.js
+++ b/frontend/store/users.js
@@ -15,7 +15,18 @@ export const state = () => ({
 })
 
 export const getters = {
-  searchParameters: (state) => state.searchParameters
+  searchParameters: (state) => state.searchParameters,
+  shapedSearchParameters: (state) => {
+    // 設定されたパラメータだけを抽出
+    return Object.entries(state.searchParameters)
+      .filter(([key, val]) => {
+        return val !== null
+      })
+      .reduce((result, current) => {
+        result[current[0]] = current[1]
+        return result
+      }, {})
+  }
 }
 
 export const mutations = {

--- a/frontend/store/users.js
+++ b/frontend/store/users.js
@@ -1,13 +1,16 @@
 export const state = () => ({
   searchParameters: {
-    text: '',
-    page: 1,
-    seriousness: 0,
-    gender: 0,
-    figure: 0,
-    ageBetween: { min: null, max: null },
-    weightBetween: { min: null, max: null },
-    heightBetween: { min: null, max: null }
+    keywords: null,
+    page: null,
+    seriousness: null,
+    gender: null,
+    figure: null,
+    ageMin: null,
+    ageMax: null,
+    weightMin: null,
+    weightMax: null,
+    heightMin: null,
+    heightMax: null
   }
 })
 

--- a/frontend/store/users.js
+++ b/frontend/store/users.js
@@ -1,4 +1,4 @@
-export const state = () => ({
+const defaultState = {
   searchParameters: {
     keywords: null,
     page: null,
@@ -12,7 +12,9 @@ export const state = () => ({
     heightMin: null,
     heightMax: null
   }
-})
+}
+
+export const state = () => defaultState
 
 export const getters = {
   searchParameters: (state) => state.searchParameters,


### PR DESCRIPTION
close #75 

# 目的
- [x] 詳細検索ページと簡易検索バーのどちらからでも同じ仕組みでユーザーの取得ができるようにする。
- [x] ユーザー一覧ページから検索クエリのみの変更時にもユーザーの再取得をする。

# 方法案

usersストアを作成し、検索パラメーターを一式保存しておく。
ユーザー一覧ページからAPIアクセスするときは常にそのストアにある検索パラメーターを使用する。
これによって検索パラメーターがグローバルに管理される為、どこからでも同じ方法でデータ取得の管理ができる。