### PR TITLE
[fix]N+1 problem

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
 
   def self.search_user_in(page: 1, per_page: 20, search_keyword: '')
     # TODO: Sprint1の段階ではキーワードを無視して検索
-    User.page(page).per(per_page)
+    User.page(page).per(per_page).with_attached_thumbnail
   end
 
   def self.find_for_oauth(auth)


### PR DESCRIPTION
ActiveStorageで用意されているスコープ `with_attahced_#{attachement_name}` を使用することでN+1問題を解決
![n+1](https://user-images.githubusercontent.com/44107494/66798224-4a9d0900-ef48-11e9-8602-7759097799ac.JPG)

只,フロントからの画像アクセス時のログは消えていないのでコンソールは荒れたまま
![console](https://user-images.githubusercontent.com/44107494/66798574-66ed7580-ef49-11e9-8664-4757eebc2d44.JPG)
