### PR TITLE
ユーザ詳細画面のレイアウト再考

### DIFF
--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container fluid fill-height>
     <v-layout justify-center>
-      <v-flex xs12 sm6 md6>
+      <v-flex xs12 sm10 md10>
         <v-card height="70vh" class="user-card" outlined raised>
           <v-list>
             <v-list-item class="justify-center">


### PR DESCRIPTION
PC版の画面では情報が中央に寄りすぎていたため横にのばしただけ

![キャプチャ](https://user-images.githubusercontent.com/43775946/67058212-c7b9bf80-f18e-11e9-9c60-7bb657735050.PNG)
