### PR TITLE
[add]DM link & Group List link

### DIFF
--- a/frontend/layouts/TheHeader.vue
+++ b/frontend/layouts/TheHeader.vue
@@ -90,7 +90,7 @@ export default {
       { link: '/auth/mypage', icon: 'account_circle', title: 'マイページ' },
       { link: '/home', icon: 'star', title: 'おすすめユーザー' },
       { link: '/direct_messages', icon: 'message', title: 'DM一覧' },
-      { link: '/group_messages', icon: 'group', title: 'グループ' },
+      { link: '/groups', icon: 'group', title: 'グループ' },
       { link: '/users', icon: 'search', title: '検索' }
     ],
     group: [

--- a/frontend/layouts/TheHeader.vue
+++ b/frontend/layouts/TheHeader.vue
@@ -89,8 +89,8 @@ export default {
     items: [
       { link: '/auth/mypage', icon: 'account_circle', title: 'マイページ' },
       { link: '/home', icon: 'star', title: 'おすすめユーザー' },
-      { link: '/messages', icon: 'message', title: 'メッセージ' },
-      { link: '/groups', icon: 'group', title: 'グループ' },
+      { link: '/direct_messages', icon: 'message', title: 'DM一覧' },
+      { link: '/group_messages', icon: 'group', title: 'グループ' },
       { link: '/users', icon: 'search', title: '検索' }
     ],
     group: [


### PR DESCRIPTION
connect to #159 

# 概要
Headerのユーザメニューの項目にリンクを付与した

# 変更点

- 「メッセージ」項目を「DM一覧」に変更してDM一覧ページへのリンクを付与した
- ~「グループ」項目にグループメッセージ一覧へのリンクを付与した~
- 「グループ」項目にグループ一覧へのリンクを付与した
# スクリーンショット
![msg](https://user-images.githubusercontent.com/44107494/68724147-090e8500-05fe-11ea-8f74-6b665906cf5b.JPG)

# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
