### PR TITLE
Add ER shape

### DIFF
--- a/docs/ER.md
+++ b/docs/ER.md
@@ -95,6 +95,7 @@ entity "friends" {
     ==
     # user_id [FK(user,id)]
     # target_id [FK(user,id)]
+    is_pending:boolean
 }
 users --|{ friends
 users }|-- friends

--- a/docs/ER.md
+++ b/docs/ER.md
@@ -96,7 +96,8 @@ entity "friends" {
     # user_id [FK(user,id)]
     # target_id [FK(user,id)]
 }
-users --o{ friends
+users --|{ friends
+users }|-- friends
 
 @enduml
 ```

--- a/docs/ER.md
+++ b/docs/ER.md
@@ -90,5 +90,13 @@ entity "direct_messages" {
 users --o{ direct_message_groups
 direct_message_groups --o{ direct_messages
 
+entity "friends" {
+    + id [PK]
+    ==
+    # user_id [FK(user,id)]
+    # target_id [FK(user,id)]
+}
+users --o{ friends
+
 @enduml
 ```


### PR DESCRIPTION
# 概要

友達関係を表すテーブルを追加。
友達という1対1の関係なので主従はないから、そのあたりをフラットにする制御はアプリケーションでやる必要がありそう。(user_idとtarget_idが逆転したレコードも生成不可にするなど)

# スクリーンショット
<img width="1223" alt="スクリーンショット 2019-11-14 13 43 05" src="https://user-images.githubusercontent.com/22770924/68827272-b78cf580-06e4-11ea-815c-c325f425c37a.png">
