### PR TITLE
Fix 'A server is already running. Check /backend/tmp/pids/server.pid'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     tty: true
     build: ./backend
     container_name: 'api_rails'
-    command: bundle exec rails s  -p 8080 -b '0.0.0.0'
+    command: rm -f tmp/pids/server.pid && bundle exec rails s -p 8080 -b '0.0.0.0'
     volumes:
       - ./backend:/backend
     ports:


### PR DESCRIPTION
# 概要

APIのDockerが正常終了しなかった時でも、次回正常に起動するためのスクリプトを追加
