### PR TITLE
Update login logic

### DIFF
--- a/frontend/pages/redirect.vue
+++ b/frontend/pages/redirect.vue
@@ -9,29 +9,29 @@ export default {
     if (!state.loggedIn) {
       console.error('認証できませんでした')
       return this.$router.push('/auth/login')
-    } else {
-      const postData = {
-        uid: state.user.id,
-        provider: state.strategy,
-        email: state.user.email
-      }
+    }
 
-      try {
-        const res = await this.$axios.$post('/api/auth/sign_in', postData)
-        this.$store.dispatch('auth/setCurrentUser', { user: res.data })
-        if (
-          res.data.email === '' ||
-          res.data.email === null ||
-          typeof res.data.email === 'undefined'
-        ) {
-          this.$router.push('/register')
-        } else {
-          this.$router.push('/home')
-        }
-      } catch (err) {
-        console.error(err)
-        this.$router.push('/auth/login')
+    const postData = {
+      uid: state.user.id,
+      provider: state.strategy,
+      email: state.user.email
+    }
+
+    try {
+      const res = await this.$axios.$post('/api/auth/sign_in', postData)
+      this.$store.dispatch('auth/setCurrentUser', { user: res.data })
+      if (
+        res.data.email === '' ||
+        res.data.email === null ||
+        typeof res.data.email === 'undefined'
+      ) {
+        this.$router.push('/register')
+      } else {
+        this.$router.push('/home')
       }
+    } catch (err) {
+      console.error(err)
+      this.$router.push('/auth/login')
     }
   }
 }

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -33,6 +33,7 @@
     </v-col>
   </v-container>
 </template>
+
 <script>
 import { required, email } from 'vuelidate/lib/validators'
 export default {
@@ -64,23 +65,22 @@ export default {
       this.$v.$touch()
       if (this.$v.$invalid) {
         this.errMsg = '未入力の項目があります'
-      } else {
-        const user = this.$store.getters['auth/currentUser']
-        const postData = {
-          id: user.id,
-          email: this.email
-        }
-        try {
-          await this.$axios.$patch('/api/users/' + postData.id, postData)
-          this.$router.push('/sign_up')
-        } catch (err) {
-          if (!err.response.status) {
-            this.$router.push('/')
-          } else if (err.response.status === 422) {
-            this.validErrors.email = err.response.data.errors.message
-          } else {
-            this.$router.push('/')
-          }
+        return
+      }
+
+      const user = this.$store.getters['auth/currentUser']
+      const postData = {
+        id: user.id,
+        email: this.email
+      }
+      try {
+        await this.$axios.$patch('/api/users/' + postData.id, postData)
+        this.$router.push('/sign_up')
+      } catch (err) {
+        if (err.response.status === 422) {
+          this.validErrors.email = err.response.data.errors.message
+        } else {
+          this.$router.push('/')
         }
       }
     }

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -1,35 +1,35 @@
 <template>
   <v-container>
     <v-col cols="12" sm="6" offset-sm="3">
-      <div class="text-center">
-        <h3 class="margin">メールアドレスの設定</h3>
-        <h5 class="red--text">
-          Facebookでメールアドレスが設定されていませんでした。
-        </h5>
-        <form>
-          <v-text-field
-            v-model="$v.email.$model"
-            :error-messages="emailErrors"
-            label="kobedenshi@gmail.com"
-            prepend-icon="email"
-            single-line
-            required
-            @input="$v.email.$touch()"
-            @blur="$v.email.$touch()"
-          />
-          <v-alert
-            v-if="validErrors.email"
-            border="right"
-            colored-border
-            type="error"
-            elevation="2"
-          >
-            {{ validErrors.email }}
-          </v-alert>
-          <v-btn class="primary" rounded @click="submit">submit</v-btn>
-          <h5 v-if="errMsg" class="red--text">{{ errMsg }}</h5>
-        </form>
-      </div>
+      <h3 class="margin">メールアドレスの設定</h3>
+      <p>
+        Facebookでメールアドレスが設定されていなかったため設定してください。
+      </p>
+      <form>
+        <v-text-field
+          v-model="$v.email.$model"
+          :error-messages="emailErrors"
+          label="hello@example.com"
+          prepend-icon="email"
+          single-line
+          required
+          @input="$v.email.$touch()"
+          @blur="$v.email.$touch()"
+        />
+        <v-alert
+          v-if="validErrors.email"
+          border="right"
+          colored-border
+          type="error"
+          elevation="2"
+        >
+          {{ validErrors.email }}
+        </v-alert>
+
+        <div class="text-center mt-4">
+          <v-btn class="primary" rounded @click="submit">設定する</v-btn>
+        </div>
+      </form>
     </v-col>
   </v-container>
 </template>


### PR DESCRIPTION
# 概要

#129 を解決するためまずリファクタリング。

本題を解決するにはAPI側で仮ログインのような仕組みを作る必要がありそう。
- Emailを設定していない場合の弱い権限
- アクセストークンのライフタイムを10分などにするなど
- もしくは一旦スルーする

# 変更点

- その他少しリファクタリング
- `register.vue`のUIを少し変更
- `pages/sign_up.vue`をauthディレクトリに格納

# スクリーンショット

`pages/register.vue`
<img width="376" alt="スクリーンショット 2019-11-14 22 25 39" src="https://user-images.githubusercontent.com/22770924/68860871-b502be00-072d-11ea-8e4f-4703fd9aa314.png">
<img width="1563" alt="スクリーンショット 2019-11-14 22 25 33" src="https://user-images.githubusercontent.com/22770924/68860872-b502be00-072d-11ea-91be-7387e24c7867.png">

