### PR TITLE
Add dm list page

### DIFF
--- a/backend/app/controllers/mock/direct_message_groups_controller.rb
+++ b/backend/app/controllers/mock/direct_message_groups_controller.rb
@@ -1,0 +1,36 @@
+module Mock
+  class DirectMessageGroupsController < ApplicationController
+    def index
+      user = User.all.limit(1).first
+      data = [
+        {
+          "id": 1,
+          "by_user": UserSerializer.new(current_user).as_json,
+          "to_user": UserSerializer.new(user).as_json,
+          "created_at": "2019-11-19 04:58:55",
+          "updated_at": "2019-11-19 04:58:55",
+          "latest_message": {
+            "id": 1,
+            "body": "君はもうバッチリ筋肉追い込んだかい！！？",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          }
+        },
+        {
+          "id": 2,
+          "by_user": UserSerializer.new(current_user).as_json,
+          "to_user": UserSerializer.new(user).as_json,
+          "created_at": "2019-11-19 04:58:55",
+          "updated_at": "2019-11-19 04:58:55",
+          "latest_message": {
+            "id": 1,
+            "body": "君はもうバッチリ筋肉追い込んだかい！！？",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          }
+        },
+      ]
+      success_res(200, message: '[Mock]: 取得しました', data: data) and return
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,15 @@
 Rails.application.routes.draw do
   root :to => "users#index"
 
+  # HACK: mock
+  namespace :mock, defaults: { format: :json } do
+    scope :api do
+      scope :user do
+        resources :direct_message_groups, only: [:index]
+      end
+    end
+  end
+
   namespace 'api', defaults: { format: :json } do
     namespace 'auth' do
       post '/sign_in', to: 'oauth#facebook'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4766,9 +4766,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "events": {
       "version": "3.0.0",
@@ -5251,9 +5251,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
-      "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
       "requires": {
         "debug": "^3.0.0"
       }
@@ -5794,11 +5794,11 @@
       }
     },
     "http-proxy": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
       "requires": {
-        "eventemitter3": "^3.0.0",
+        "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
       }

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -1,5 +1,81 @@
 <template>
   <div>
     <h1>DM一覧</h1>
+
+    <v-card max-width="450" class="mx-auto">
+      <v-list three-line>
+        <template v-for="(item, index) in computed_direct_message_groups">
+          <v-list-item :key="index">
+            <v-list-item-avatar>
+              <v-img :src="item.opponent.thumbnail"></v-img>
+            </v-list-item-avatar>
+
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ item.opponent.nickname }}
+                <span class="grey--text text--lighten-1">
+                  {{ item.latest_message.created_at }}
+                </span>
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                {{ item.latest_message.body }}
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+
+          <v-divider
+            v-if="isNotLast(index)"
+            :key="index"
+            :inset="true"
+          ></v-divider>
+        </template>
+      </v-list>
+    </v-card>
   </div>
 </template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  middleware: 'auth',
+
+  data: () => ({
+    direct_message_groups: []
+  }),
+
+  async asyncData({ $axios }) {
+    const groups = await $axios
+      .$get('/mock/api/user/direct_message_groups')
+      .then((res) => res.data)
+      .catch(() => [])
+
+    return {
+      direct_message_groups: groups
+    }
+  },
+
+  computed: {
+    ...mapGetters({
+      currentUser: 'auth/currentUser'
+    }),
+    computed_direct_message_groups() {
+      return this.direct_message_groups.reduce((result, current) => {
+        if (current.to_user.id !== this.currentUser.id) {
+          current.opponent = current.to_user
+        } else {
+          current.opponent = current.by_user
+        }
+        result.push(current)
+        return result
+      }, [])
+    }
+  },
+
+  methods: {
+    isNotLast(index) {
+      return index + 1 < this.computed_direct_message_groups.length
+    }
+  }
+}
+</script>

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -3,9 +3,9 @@
     <h1>DM一覧</h1>
 
     <v-card max-width="450" class="mx-auto">
-      <v-list three-line>
-        <template v-for="(item, index) in computed_direct_message_groups">
-          <v-list-item :key="index">
+      <template v-for="(item, index) in computed_direct_message_groups">
+        <v-list :key="index" three-line>
+          <v-list-item :to="`/direct_messages/${item.id}`">
             <v-list-item-avatar>
               <v-img :src="item.opponent.thumbnail"></v-img>
             </v-list-item-avatar>
@@ -28,8 +28,8 @@
             :key="index"
             :inset="true"
           ></v-divider>
-        </template>
-      </v-list>
+        </v-list>
+      </template>
     </v-card>
   </div>
 </template>


### PR DESCRIPTION
connect to #148 

# 概要

DMGroup一覧画面のモックと画面を作成

# 変更点

- RailsでDMGroupsのモックを作成
- DMGroup一覧画面を作成

# スクリーンショット
<img width="377" alt="スクリーンショット 2019-11-18 15 09 07" src="https://user-images.githubusercontent.com/22770924/69028507-862e6580-0a15-11ea-8a86-1653563e8111.png">

# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

@Raccoo 
Rails側にモックを書いた理由

https://pbl2-scrum.slack.com/archives/CLJPR8W3Z/p1574048813003300
<img width="665" alt="スクリーンショット 2019-11-18 15 10 37" src="https://user-images.githubusercontent.com/22770924/69028534-9e05e980-0a15-11ea-967a-3117cc6e7f12.png">

