### PR TITLE
Add dm page

### DIFF
--- a/backend/app/controllers/mock/direct_message_groups_controller.rb
+++ b/backend/app/controllers/mock/direct_message_groups_controller.rb
@@ -67,5 +67,30 @@ module Mock
       }
       success_res(200, message: '[Mock]: 取得しました', data: data) and return
     end
+
+    def create
+      if direct_message_params['message'].blank?
+        error_res(
+          400,
+          message: "不正なリクエストです",
+          err: "不正なリクエストです"
+        ) and return
+      end
+
+      data = {
+        id: 1,
+        body: direct_message_params['message'],
+        send_user_id: current_user.id,
+        created_at: "2019-11-19 04:58:55",
+        updated_at: "2019-11-19 04:58:55"
+      }
+      success_res(200, message: '[Mock]: 作成しました', data: data) and return
+    end
+
+    private
+
+    def direct_message_params
+      params.permit(:message)
+    end
   end
 end

--- a/backend/app/controllers/mock/direct_message_groups_controller.rb
+++ b/backend/app/controllers/mock/direct_message_groups_controller.rb
@@ -32,5 +32,40 @@ module Mock
       ]
       success_res(200, message: '[Mock]: 取得しました', data: data) and return
     end
+
+    def show
+      user = User.all.limit(1).first
+      data = {
+        "id": 1,
+        "by_user": UserSerializer.new(current_user).as_json,
+        "to_user": UserSerializer.new(user).as_json,
+        "created_at": "2019-11-19 04:58:55",
+        "updated_at": "2019-11-19 04:58:55",
+        "direct_messages": [
+          {
+            "id": 1,
+            "body": "Hello, Mr.Muscler!",
+            "send_user_id": user.id,
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          },
+          {
+            "id": 2,
+            "body": "Hello, Mr!",
+            "send_user_id": current_user.id,
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          },
+          {
+            "id": 3,
+            "body": "Let's workout together quadriceps femoris muscle !! 一緒に大腿四頭筋を鍛えましょう！!",
+            "send_user_id": user.id,
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          },
+        ]
+      }
+      success_res(200, message: '[Mock]: 取得しました', data: data) and return
+    end
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   namespace :mock, defaults: { format: :json } do
     scope :api do
       scope :user do
-        resources :direct_message_groups, only: [:index, :show]
+        resources :direct_message_groups, only: [:index, :show] do
+          post '/', to: 'direct_message_groups#create'
+        end
       end
     end
   end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   namespace :mock, defaults: { format: :json } do
     scope :api do
       scope :user do
-        resources :direct_message_groups, only: [:index]
+        resources :direct_message_groups, only: [:index, :show]
       end
     end
   end

--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h1>{{ nickname }}さんとのDM</h1>
+    <h1>さんとのDM</h1>
 
     <v-card max-width="450" class="mx-auto chat-card">
       <template v-for="(item, index) in directMessages">
@@ -31,8 +31,21 @@
           outlined
           label="Message"
           type="text"
-          append-outer-icon="mdi-send"
-        ></v-text-field>
+          required
+          @keydown.enter="sendMessage"
+        >
+          <template v-slot:append-outer>
+            <v-fade-transition leave-absolute>
+              <v-progress-circular
+                v-if="sending"
+                size="24"
+                color="info"
+                indeterminate
+              ></v-progress-circular>
+              <v-icon v-else @click="sendMessage">mdi-send</v-icon>
+            </v-fade-transition>
+          </template>
+        </v-text-field>
       </v-col>
     </v-card>
   </div>
@@ -84,6 +97,27 @@ export default {
     },
     isNotLast(index) {
       return index + 1 < this.directMessages.length
+    },
+    async sendMessage(e) {
+      // 日本語変換でもkeydownが発火してしまうため処理で制御
+      if (e.type !== 'click' && e.keyCode !== 13) return
+
+      this.sending = true
+      await this.$axios
+        .$post(
+          `/mock/api/user/direct_message_groups/${this.$route.params.id}`,
+          { message: this.message }
+        )
+        .then((res) => {
+          const message = res.data
+          console.log(message)
+          this.directMessages.push(message)
+
+          this.sending = false
+        })
+        .catch(() => {
+          this.sending = false
+        })
     }
   }
 }

--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <h1>{{ getUserBy($route.params.id).nickname }}さんとのDM</h1>
+    <h1>{{ nickname }}さんとのDM</h1>
 
-    <v-card max-width="450" class="mx-auto">
+    <v-card max-width="450" class="mx-auto chat-card">
       <template v-for="(item, index) in directMessages">
         <v-list :key="index" three-line class="pa-0">
           <v-list-item>
@@ -24,6 +24,16 @@
           </v-list-item>
         </v-list>
       </template>
+
+      <v-col cols="12" class="mt-12 chat-message-box">
+        <v-text-field
+          v-model="message"
+          outlined
+          label="Message"
+          type="text"
+          append-outer-icon="mdi-send"
+        ></v-text-field>
+      </v-col>
     </v-card>
   </div>
 </template>
@@ -40,7 +50,9 @@ export default {
 
   data: () => ({
     directMessageGroup: null,
-    directMessages: null
+    directMessages: null,
+    message: '',
+    sending: false
   }),
 
   computed: {
@@ -76,3 +88,15 @@ export default {
   }
 }
 </script>
+
+<style>
+.chat-card {
+  height: 74vh;
+  position: relative;
+}
+
+.chat-message-box {
+  position: absolute;
+  bottom: 0;
+}
+</style>

--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -1,13 +1,78 @@
 <template>
   <div>
-    <h1>{{ $route.params.id }}さんとのDM</h1>
+    <h1>{{ getUserBy($route.params.id).nickname }}さんとのDM</h1>
+
+    <v-card max-width="450" class="mx-auto">
+      <template v-for="(item, index) in directMessages">
+        <v-list :key="index" three-line class="pa-0">
+          <v-list-item>
+            <v-list-item-avatar>
+              <v-img :src="getUserBy(item.send_user_id).thumbnail"></v-img>
+            </v-list-item-avatar>
+
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ getUserBy(item.send_user_id).nickname || 'unknown' }}
+                <span class="grey--text text--lighten-1">
+                  {{ item.updated_at }}
+                </span>
+              </v-list-item-title>
+              <v-list-item-subtitle class="d-block">
+                {{ item.body }}
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </template>
+    </v-card>
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
+  middleware: 'auth',
+
   validate({ params }) {
     return /^\d+$/.test(params.id)
+  },
+
+  data: () => ({
+    directMessageGroup: null,
+    directMessages: null
+  }),
+
+  computed: {
+    ...mapGetters({
+      currentUser: 'auth/currentUser'
+    })
+  },
+
+  async asyncData({ $axios, params }) {
+    const dmGroup = await $axios
+      .$get(`/mock/api/user/direct_message_groups/${params.id}`)
+      .then((res) => res.data)
+      .catch(() => null)
+    const directMessages = dmGroup ? dmGroup.direct_messages : null
+
+    return {
+      directMessageGroup: dmGroup,
+      directMessages
+    }
+  },
+
+  methods: {
+    getUserBy(id) {
+      if (id === this.directMessageGroup.to_user.id) {
+        return this.directMessageGroup.to_user
+      }
+
+      return this.directMessageGroup.by_user
+    },
+    isNotLast(index) {
+      return index + 1 < this.directMessages.length
+    }
   }
 }
 </script>

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -3,7 +3,7 @@
     <h1>DM一覧</h1>
 
     <v-card max-width="450" class="mx-auto">
-      <template v-for="(item, index) in computed_direct_message_groups">
+      <template v-for="(item, index) in computedDirectMessageGroups">
         <v-list :key="index" three-line>
           <v-list-item :to="`/direct_messages/${item.id}`">
             <v-list-item-avatar>
@@ -41,7 +41,7 @@ export default {
   middleware: 'auth',
 
   data: () => ({
-    direct_message_groups: []
+    directMessageGroups: []
   }),
 
   async asyncData({ $axios }) {
@@ -51,7 +51,7 @@ export default {
       .catch(() => [])
 
     return {
-      direct_message_groups: groups
+      directMessageGroups: groups
     }
   },
 
@@ -59,8 +59,8 @@ export default {
     ...mapGetters({
       currentUser: 'auth/currentUser'
     }),
-    computed_direct_message_groups() {
-      return this.direct_message_groups.reduce((result, current) => {
+    computedDirectMessageGroups() {
+      return this.directMessageGroups.reduce((result, current) => {
         if (current.to_user.id !== this.currentUser.id) {
           current.opponent = current.to_user
         } else {
@@ -74,7 +74,7 @@ export default {
 
   methods: {
     isNotLast(index) {
-      return index + 1 < this.computed_direct_message_groups.length
+      return index + 1 < this.computedDirectMessageGroups.length
     }
   }
 }


### PR DESCRIPTION
connect to #149 

# 概要
DMの詳細画面を作成

# 変更点

- DMの詳細画面を作成
- DM詳細とDM送信のモックを作成

# スクリーンショット
<img width="394" alt="スクリーンショット 2019-11-20 20 47 43" src="https://user-images.githubusercontent.com/22770924/69236517-064ff900-0bd7-11ea-8417-8ade56bfb57d.png">


# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
