### PR TITLE
Add groups page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setenv reinit init run down ps migrate lintfix
+.PHONY: setenv reinit init run down ps migrate lintfix railsc
 
 setenv: environments
 	cp environments/.env ./
@@ -31,6 +31,8 @@ migrate:
 lintfix:
 	docker-compose exec frontend npm run lintfix
 
+railsc:
+	docker-compose exec api bundle exec rails c
 
 .PHONY: mock/*
 

--- a/backend/app/controllers/mock/groups_controller.rb
+++ b/backend/app/controllers/mock/groups_controller.rb
@@ -1,0 +1,41 @@
+module Mock
+  class GroupsController < ApplicationController
+
+    def index
+      data = []
+      names = ['筋肉モンスターの集会所', 'ゴリラ教団', 'ITエンジニア達の筋活!']
+      10.times do |i|
+        data << {
+          "id": i + 1,
+          "name": names[i % 3],
+          "description": "筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！",
+          "is_public": true,
+          "thumbnail": "https://i2.wp.com/dietlife25.com/wp-content/uploads/2019/12/274122b394996dcc766774e82f1bdf0e_m.jpg?resize=1280%2C720&ssl=1",
+          "tags": [
+            {
+              "id": 1,
+              "name": "マッチョ",
+              "created_at": "2019-11-19 04:58:55",
+              "updated_at": "2019-11-19 04:58:55"
+            },
+            {
+              "id": 2,
+              "name": "人生",
+              "created_at": "2019-11-19 04:58:55",
+              "updated_at": "2019-11-19 04:58:55"
+            },
+            {
+              "id": 3,
+              "name": "エンジニア",
+              "created_at": "2019-11-19 04:58:55",
+              "updated_at": "2019-11-19 04:58:55"
+            }
+          ],
+          "created_at": "2019-11-19 04:58:55",
+          "updated_at": "2019-11-19 04:58:55"
+        }
+      end
+      success_res(200, message: '[Mock]: 取得しました', data: data) and return
+    end
+  end
+end

--- a/backend/app/controllers/mock/groups_controller.rb
+++ b/backend/app/controllers/mock/groups_controller.rb
@@ -37,5 +37,38 @@ module Mock
       end
       success_res(200, message: '[Mock]: 取得しました', data: data) and return
     end
+
+    def show
+      data = {
+        "id": 3,
+        "name": 'ITエンジニア達の筋活!',
+        "description": "筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！",
+        "is_public": true,
+        "thumbnail": "https://i2.wp.com/dietlife25.com/wp-content/uploads/2019/12/274122b394996dcc766774e82f1bdf0e_m.jpg?resize=1280%2C720&ssl=1",
+        "tags": [
+          {
+            "id": 1,
+            "name": "マッチョ",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          },
+          {
+            "id": 2,
+            "name": "人生",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          },
+          {
+            "id": 3,
+            "name": "エンジニア",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          }
+        ],
+        "created_at": "2019-11-19 04:58:55",
+        "updated_at": "2019-11-19 04:58:55"
+      }
+      success_res(200, message: '[Mock]: 取得しました', data: data) and return
+    end
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
           post '/', to: 'direct_message_groups#create'
         end
       end
-      resources :groups, only: [:index]
+      resources :groups, only: [:index, :show]
     end
   end
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
           post '/', to: 'direct_message_groups#create'
         end
       end
+      resources :groups, only: [:index]
     end
   end
 

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -1,6 +1,36 @@
 <template>
   <div>
-    <h1>「{{ $route.params.id }}」グループの詳細ページ</h1>
+    <v-btn to="/groups" class="mb-4" text small>戻る</v-btn>
+    <p class="grey--text text--lighten-1">{{ group.created_at }}作成</p>
+    <v-flex>
+      <h1>「{{ group.name }}」グループ</h1>
+      <div v-if="!group.is_public"><v-icon>lock</v-icon></div>
+    </v-flex>
+
+    <template v-for="tag in group.tags">
+      <v-btn :key="tag.id" color="darkgray" class="mr-2 mb-1" depressed small>
+        {{ tag.name }}
+      </v-btn>
+    </template>
+
+    <v-tabs v-model="tab" class="mt-6" background-color="transparent">
+      <v-tab v-for="(item, index) in tabs" :key="index">
+        {{ item }}
+      </v-tab>
+
+      <v-tabs-items v-model="tab" class="mt-6">
+        <v-tab-item class="flat-background">
+          <h5 class="mb-2">概要</h5>
+          {{ group.description }}
+        </v-tab-item>
+        <v-tab-item class="flat-background">
+          グループチャット
+        </v-tab-item>
+        <v-tab-item class="flat-background">
+          グループメンバー
+        </v-tab-item>
+      </v-tabs-items>
+    </v-tabs>
   </div>
 </template>
 
@@ -8,6 +38,32 @@
 export default {
   validate({ params }) {
     return /^\d+$/.test(params.id)
+  },
+
+  data: () => ({
+    group: null,
+    tabs: ['詳細', 'チャット', 'メンバー'],
+    tab: null
+  }),
+
+  async asyncData({ $axios, params }) {
+    const group = await $axios
+      .$get(`/mock/api/groups/${params.id}`)
+      .then((res) => res.data)
+
+    return {
+      group
+    }
   }
 }
 </script>
+
+<style>
+.theme--light.v-btn--active::before {
+  opacity: 0;
+}
+
+.flat-background {
+  background-color: rgb(250, 250, 250) !important;
+}
+</style>

--- a/frontend/pages/groups/index.vue
+++ b/frontend/pages/groups/index.vue
@@ -1,5 +1,86 @@
 <template>
   <div>
     <h1>グループ一覧</h1>
+
+    <v-list v-if="groups">
+      <v-row>
+        <v-col
+          v-for="group in groups"
+          :key="group.id"
+          cols="12"
+          xl="3"
+          lg="3"
+          md="3"
+          sm="3"
+        >
+          <v-card
+            class="mx-auto my-4"
+            max-width="374"
+            max-height="530"
+            min-height="530"
+          >
+            <nuxt-link :to="{ name: 'groups-id', params: { id: group.id } }">
+              <v-img
+                height="300"
+                :src="
+                  group.thumbnail ||
+                    'https://data.ac-illust.com/data/thumbnails/e3/e3879bde102fa55e1b15630f564e7df1_w.jpeg'
+                "
+              ></v-img>
+            </nuxt-link>
+            <v-card-title class="pb-0">
+              <nuxt-link :to="{ name: 'groups-id', params: { id: group.id } }">
+                {{ group.name }}
+              </nuxt-link>
+            </v-card-title>
+
+            <v-card-text class="pb-1">
+              <div class="black--text sub-info-text">
+                タグ:&nbsp;
+                <template v-for="tag in group.tags">
+                  {{ tag.name + ' ' }}
+                </template>
+              </div>
+              <div class="mb-4 grey--text text--lighten-1">
+                {{ group.created_at }}結成
+              </div>
+              <div class="card-body-overflow" v-text="group.description"></div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-list>
+    <div v-else>
+      グループが存在しません
+    </div>
   </div>
 </template>
+
+<script>
+export default {
+  data: () => ({
+    groups: []
+  }),
+
+  async asyncData({ $axios }) {
+    const groups = await $axios.$get('/mock/api/groups').then((res) => res.data)
+
+    return {
+      groups
+    }
+  }
+}
+</script>
+
+<style>
+.card-body-overflow {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  min-height: 5em;
+}
+.sub-info-text {
+  font-size: 14px;
+}
+</style>


### PR DESCRIPTION
connect to #181 

# 概要

グループ一覧画面を作成

# 変更点

- `rails console`を開くためのショートカットを追加
- グループ一覧のモックを作成
- グループ一覧画面を作成

# スクリーンショット

<img width="1564" alt="スクリーンショット 2019-11-21 11 12 25" src="https://user-images.githubusercontent.com/22770924/69298133-51f2b900-0c50-11ea-97d7-1e0ca894cc0b.png">


# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
