### PR TITLE
Add group page

### DIFF
--- a/backend/app/controllers/mock/groups_controller.rb
+++ b/backend/app/controllers/mock/groups_controller.rb
@@ -37,5 +37,38 @@ module Mock
       end
       success_res(200, message: '[Mock]: 取得しました', data: data) and return
     end
+
+    def show
+      data = {
+        "id": 3,
+        "name": 'ITエンジニア達の筋活!',
+        "description": "筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！筋肉は全てを解決してくれる！",
+        "is_public": true,
+        "thumbnail": "https://i2.wp.com/dietlife25.com/wp-content/uploads/2019/12/274122b394996dcc766774e82f1bdf0e_m.jpg?resize=1280%2C720&ssl=1",
+        "tags": [
+          {
+            "id": 1,
+            "name": "マッチョ",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          },
+          {
+            "id": 2,
+            "name": "人生",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          },
+          {
+            "id": 3,
+            "name": "エンジニア",
+            "created_at": "2019-11-19 04:58:55",
+            "updated_at": "2019-11-19 04:58:55"
+          }
+        ],
+        "created_at": "2019-11-19 04:58:55",
+        "updated_at": "2019-11-19 04:58:55"
+      }
+      success_res(200, message: '[Mock]: 取得しました', data: data) and return
+    end
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
           post '/', to: 'direct_message_groups#create'
         end
       end
-      resources :groups, only: [:index]
+      resources :groups, only: [:index, :show]
     end
   end
 

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -1,6 +1,36 @@
 <template>
   <div>
-    <h1>「{{ $route.params.id }}」グループの詳細ページ</h1>
+    <v-btn to="/groups" class="mb-4" text small>戻る</v-btn>
+    <p class="grey--text text--lighten-1">{{ group.created_at }}作成</p>
+    <v-flex>
+      <h1>「{{ group.name }}」グループ</h1>
+      <div v-if="!group.is_public"><v-icon>lock</v-icon></div>
+    </v-flex>
+
+    <template v-for="tag in group.tags">
+      <v-btn :key="tag.id" color="darkgray" class="mr-2 mb-1" depressed small>
+        {{ tag.name }}
+      </v-btn>
+    </template>
+
+    <v-tabs v-model="tab" class="mt-6" background-color="transparent">
+      <v-tab v-for="(item, index) in tabs" :key="index">
+        {{ item }}
+      </v-tab>
+
+      <v-tabs-items v-model="tab" class="mt-6">
+        <v-tab-item class="flat-background">
+          <h5 class="mb-2">概要</h5>
+          {{ group.description }}
+        </v-tab-item>
+        <v-tab-item class="flat-background">
+          グループチャット
+        </v-tab-item>
+        <v-tab-item class="flat-background">
+          グループメンバー
+        </v-tab-item>
+      </v-tabs-items>
+    </v-tabs>
   </div>
 </template>
 
@@ -8,6 +38,32 @@
 export default {
   validate({ params }) {
     return /^\d+$/.test(params.id)
+  },
+
+  data: () => ({
+    group: null,
+    tabs: ['詳細', 'チャット', 'メンバー'],
+    tab: null
+  }),
+
+  async asyncData({ $axios, params }) {
+    const group = await $axios
+      .$get(`/mock/api/groups/${params.id}`)
+      .then((res) => res.data)
+
+    return {
+      group
+    }
   }
 }
 </script>
+
+<style>
+.theme--light.v-btn--active::before {
+  opacity: 0;
+}
+
+.flat-background {
+  background-color: rgb(250, 250, 250) !important;
+}
+</style>


### PR DESCRIPTION
connect to #183 

# 概要

グループ詳細ページとモックを追加。
メンバー一覧とかチャット一覧とかをとりあえずタブで作ったが、まだ実装はしていない。

# スクリーンショット
<img width="378" alt="スクリーンショット 2019-11-21 14 31 47" src="https://user-images.githubusercontent.com/22770924/69306799-1f56b980-0c6c-11ea-8e49-e609106692b0.png">
<img width="375" alt="スクリーンショット 2019-11-21 14 31 55" src="https://user-images.githubusercontent.com/22770924/69306801-1f56b980-0c6c-11ea-83e3-9b657eafd577.png">

# 関連issue

- #172 

# 留意事項・参考

留意事項や参考があれば
