### PR TITLE
[ADD]Dm group list api

### DIFF
--- a/backend/app/controllers/api/direct_message_groups_controller.rb
+++ b/backend/app/controllers/api/direct_message_groups_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  class DirectMessageGroupsController < ApplicationController
+    include DateHelper
+    def index
+      user = User.find(current_user.id)
+      data = make_dm_list_data
+      success_res(200, message: '取得しました', data: data) and return
+    end
+
+    private
+
+    def make_dm_list_data
+      data = []
+      current_user = User.find(@current_user.id)
+
+      current_user_dm_list = []
+      current_user_dm_list += current_user.by_users
+      current_user_dm_list += current_user.to_users
+
+      unless current_user_dm_list.present?
+        data
+      end
+
+      current_user_dm_list.each do |item|
+        latest_message = DirectMessage.where(direct_message_group_id:item.id).order(created_at: "DESC").first
+
+        by_user = User.find(item.by_user_id)
+        to_user = User.find(item.to_user_id)
+
+        data << {
+          "id": item.id,
+          "by_user": UserSerializer.new(by_user).as_json,
+          "to_user": UserSerializer.new(to_user).as_json,
+          "created_at": created_date(item.created_at),
+          "updated_at": updated_date(item.updated_at),
+          "latest_message": LatestMessageSerializer.new(latest_message).as_json
+        }
+      end
+
+      data
+    end
+
+  end
+end
+  

--- a/backend/app/controllers/api/direct_message_groups_controller.rb
+++ b/backend/app/controllers/api/direct_message_groups_controller.rb
@@ -10,11 +10,10 @@ module Api
     private
 
     def make_dm_list_data
-      data = []
       current_user_dm_list = [] + current_user.by_users + current_user.to_users
 
       unless current_user_dm_list.present?
-        nil
+        return nil
       end
 
       users_data = make_user_data_of_dm_list_hash(current_user_dm_list)
@@ -22,7 +21,7 @@ module Api
 
       current_user_dm_list.map do |item|
         latest_message = latest_messages.find { |message| message.direct_message_group_id == item.id }
-        data << {
+        {
           "id": item.id,
           "by_user": UserSerializer.new(users_data.find {|user| user.id == item.by_user_id }).as_json,
           "to_user": UserSerializer.new(users_data.find {|user| user.id == item.to_user_id }).as_json,
@@ -45,16 +44,12 @@ module Api
         end
       end
 
-      users_data = User.fetch_users(user_ids)
-
-      users_data
+      User.fetch_users(user_ids)
     end
 
     def make_latest_messages_hash(dm_list)
       direct_message_group_ids = dm_list.map {|item| item.id }.uniq
-      direct_messages = DirectMessage.fetch_direct_message_data(direct_message_group_ids)
-
-      direct_messages
+      DirectMessage.fetch_direct_message_data(direct_message_group_ids)
     end
 
   end

--- a/backend/app/controllers/api/direct_message_groups_controller.rb
+++ b/backend/app/controllers/api/direct_message_groups_controller.rb
@@ -41,18 +41,18 @@ module Api
     end
 
     def make_user_data_of_dm_list_hash(dm_list)
-      user_id_list = []
+      user_ids = []
       dm_list.each do |item|
-        unless user_id_list.include?(item.by_user_id)
-          user_id_list << item.by_user_id
+        unless user_ids.include?(item.by_user_id)
+          user_ids << item.by_user_id
         end
 
-        unless user_id_list.include?(item.to_user_id)
-          user_id_list << item.to_user_id
+        unless user_ids.include?(item.to_user_id)
+          user_ids << item.to_user_id
         end
       end
 
-      users_data = User.where(id: user_id_list).with_attached_thumbnail 
+      users_data = User.fetch_users(user_ids)
       hash = users_data.map { |user| [user.id, user] }.to_h
 
       hash

--- a/backend/app/controllers/api/direct_message_groups_controller.rb
+++ b/backend/app/controllers/api/direct_message_groups_controller.rb
@@ -1,8 +1,8 @@
 module Api
   class DirectMessageGroupsController < ApplicationController
     include DateHelper
+
     def index
-      user = User.find(current_user.id)
       data = make_dm_list_data
       success_res(200, message: '取得しました', data: data) and return
     end
@@ -21,11 +21,12 @@ module Api
         data
       end
 
+      users_data_hash = fetch_user_data_of_dm_list_hash(current_user_dm_list,current_user.id)
       current_user_dm_list.each do |item|
         latest_message = DirectMessage.where(direct_message_group_id:item.id).order(created_at: "DESC").first
 
-        by_user = User.find(item.by_user_id)
-        to_user = User.find(item.to_user_id)
+        by_user = users_data_hash[item.by_user_id]
+        to_user = users_data_hash[item.to_user_id]
 
         data << {
           "id": item.id,
@@ -38,6 +39,24 @@ module Api
       end
 
       data
+    end
+
+    def fetch_user_data_of_dm_list_hash(dm_list,current_user_id)
+      user_id_list = []
+      dm_list.each do |item|
+        unless user_id_list.include?(item.by_user_id)
+          user_id_list << item.by_user_id
+        end
+
+        unless user_id_list.include?(item.to_user_id)
+          user_id_list << item.to_user_id
+        end
+      end
+
+      users_data = User.where(id: user_id_list).with_attached_thumbnail 
+      hash = users_data.map { |user| [user.id, user] }.to_h
+
+      hash
     end
 
   end

--- a/backend/app/controllers/api/direct_message_groups_controller.rb
+++ b/backend/app/controllers/api/direct_message_groups_controller.rb
@@ -11,10 +11,7 @@ module Api
 
     def make_dm_list_data
       data = []
-
-      current_user_dm_list = []
-      current_user_dm_list += current_user.by_users
-      current_user_dm_list += current_user.to_users
+      current_user_dm_list = [] + current_user.by_users + current_user.to_users
 
       unless current_user_dm_list.present?
         nil

--- a/backend/app/controllers/api/direct_message_groups_controller.rb
+++ b/backend/app/controllers/api/direct_message_groups_controller.rb
@@ -20,20 +20,17 @@ module Api
       users_data = make_user_data_of_dm_list_hash(current_user_dm_list)
       latest_messages = make_latest_messages_hash(current_user_dm_list)
 
-      current_user_dm_list.each do |item|
+      current_user_dm_list.map do |item|
         latest_message = latest_messages.find { |message| message.direct_message_group_id == item.id }
-
         data << {
           "id": item.id,
           "by_user": UserSerializer.new(users_data.find {|user| user.id == item.by_user_id }).as_json,
           "to_user": UserSerializer.new(users_data.find {|user| user.id == item.to_user_id }).as_json,
           "created_at": created_date(item.created_at),
           "updated_at": updated_date(item.updated_at),
-          "latest_message": latest_message.nil? ? LatestMessageSerializer.new(latest_message) : nil
+          "latest_message": latest_message.present? ? LatestMessageSerializer.new(latest_message) : nil
         }
       end
-
-      data
     end
 
     def make_user_data_of_dm_list_hash(dm_list)

--- a/backend/app/helpers/date_helper.rb
+++ b/backend/app/helpers/date_helper.rb
@@ -1,0 +1,9 @@
+module DateHelper
+  def created_date(created_date)
+    created_date.strftime('%Y/%m/%d %H:%M')
+  end
+
+  def updated_date(updated_date)
+    updated_date.strftime('%Y/%m/%d %H:%M')
+  end
+end

--- a/backend/app/models/direct_message.rb
+++ b/backend/app/models/direct_message.rb
@@ -1,4 +1,12 @@
 class DirectMessage < ApplicationRecord
   belongs_to  :direct_message_group
   belongs_to  :send_user, class_name: "User", foreign_key: "send_user_id"
+
+  scope :search_direct_message, ->(dm_group_id_list) {
+    where(direct_message_group_id: dm_group_id_list).order(direct_message_group_id: :DESC)
+  }
+
+  def self.fetch_direct_message_data(direct_message_group_id_list)
+    search_direct_message(direct_message_group_id_list)
+  end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -78,6 +78,10 @@ class User < ApplicationRecord
     .with_attached_thumbnail 
   }
 
+  def self.fetch_users(user_ids)
+    where(id: user_ids).with_attached_thumbnail 
+  end
+
   def self.fetch_recommend_users_in(params)
     recommend_user_list = []
     figure = params[:figure].present? ? params[:figure] : nil

--- a/backend/app/serializers/latest_message_serializer.rb
+++ b/backend/app/serializers/latest_message_serializer.rb
@@ -1,0 +1,25 @@
+class LatestMessageSerializer < ActiveModel::Serializer
+  include DateHelper
+  attributes(
+    :id,
+    :body,
+    :created_at,
+    :updated_at
+  )
+
+  def id
+    object.nil? ? "" : object.id
+  end
+
+  def body
+    object.nil? ? "" : object.body
+  end
+
+  def created_at
+    object.nil? ? "" : created_date(object.created_at)
+  end
+
+  def updated_at
+    object.nil? ? "" : updated_date(object.updated_at)
+  end
+end

--- a/backend/app/serializers/latest_message_serializer.rb
+++ b/backend/app/serializers/latest_message_serializer.rb
@@ -7,19 +7,11 @@ class LatestMessageSerializer < ActiveModel::Serializer
     :updated_at
   )
 
-  def id
-    object.nil? ? "" : object.id
-  end
-
-  def body
-    object.nil? ? "" : object.body
-  end
-
   def created_at
-    object.nil? ? "" : created_date(object.created_at)
+    created_date(object.created_at)
   end
 
   def updated_at
-    object.nil? ? "" : updated_date(object.updated_at)
+    updated_date(object.updated_at)
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -33,6 +33,11 @@ Rails.application.routes.draw do
     resources :tags do
     end
 
+    scope :user do
+      resources :direct_message_groups,only: [:index] do
+      end
+    end
+
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/backend/spec/requests/direct_message_list_api_spec.rb
+++ b/backend/spec/requests/direct_message_list_api_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'rdirect message list api', type: :request do
+  describe 'GET #index' do
+    context 'access token not exist into header' do
+      it 'return status code 401' do
+      end
+    end
+
+    context 'access token exist into header' do
+      it 'search direct message list' do
+
+      end
+    end
+  end
+end

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -14,7 +14,7 @@
               <v-list-item-title>
                 {{ item.opponent.nickname }}
                 <span
-                  v-if="item.latest_message !== null"
+                  v-if="item.latest_message"
                   class="grey--text text--lighten-1"
                 >
                   {{ item.latest_message.created_at }}
@@ -23,7 +23,7 @@
                   <v-spacer></v-spacer>
                 </span>
               </v-list-item-title>
-              <v-list-item-subtitle v-if="item.latest_message !== null">
+              <v-list-item-subtitle v-if="item.latest_message">
                 {{ item.latest_message.body }}
               </v-list-item-subtitle>
               <v-list-item-subtitle v-else>

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -46,7 +46,7 @@ export default {
 
   async asyncData({ $axios }) {
     const groups = await $axios
-      .$get('/mock/api/user/direct_message_groups')
+      .$get('api/user/direct_message_groups')
       .then((res) => res.data)
       .catch(() => [])
 

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -13,12 +13,21 @@
             <v-list-item-content>
               <v-list-item-title>
                 {{ item.opponent.nickname }}
-                <span class="grey--text text--lighten-1">
+                <span
+                  v-if="item.latest_message !== null"
+                  class="grey--text text--lighten-1"
+                >
                   {{ item.latest_message.created_at }}
                 </span>
+                <span v-else>
+                  <v-spacer></v-spacer>
+                </span>
               </v-list-item-title>
-              <v-list-item-subtitle>
+              <v-list-item-subtitle v-if="item.latest_message !== null">
                 {{ item.latest_message.body }}
+              </v-list-item-subtitle>
+              <v-list-item-subtitle v-else>
+                <v-spacer></v-spacer>
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>


### PR DESCRIPTION
close #153 

# 概要
ユーザが所持しているDM一覧を返すAPI

# 変更点

- 変更内容
- 変更内容

# スクリーンショット
<img width="540" alt="スクリーンショット 2019-11-26 15 04 43" src="https://user-images.githubusercontent.com/44107494/69603467-1c8a0900-105e-11ea-8c38-a38901ded2cc.png">

メッセージがなければ名前と相手のプロフィール画像が表示
メッセージが存在していればメッセージと最終更新日時が表示される

# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

~テストかく~