### PR TITLE
グループメッセージのタブを追加

### DIFF
--- a/backend/app/controllers/mock/direct_message_groups_controller.rb
+++ b/backend/app/controllers/mock/direct_message_groups_controller.rb
@@ -12,6 +12,7 @@ module Mock
           "latest_message": {
             "id": 1,
             "body": "君はもうバッチリ筋肉追い込んだかい！！？",
+            "send_user_id": current_user.id,
             "created_at": "2019-11-19 04:58:55",
             "updated_at": "2019-11-19 04:58:55"
           }

--- a/backend/app/controllers/mock/group_messages_controller.rb
+++ b/backend/app/controllers/mock/group_messages_controller.rb
@@ -1,0 +1,34 @@
+module Mock
+  class GroupMessagesController < ApplicationController
+    skip_before_action :authenticate_user_from_token!, only: [:show]
+
+    def show
+      users = User.all.limit(4).to_a
+
+      messages = [
+        'お願いマッスル めっちゃモテたい！お願いマッスル めっちゃ痩せたい、YES！',
+        'ウー！(キレてるよ！) ハー！(キレてるよ！)',
+        'ヒップレイズ！サイドベント！腹筋6LDKかい！',
+        'ダンベルカール！ハンマーカール！二頭が良いね！チョモランマ！',
+        'プッシュアップ！ベンチプレス！ 大胸筋が歩いてる！仕上がってるよ！仕上がってるよ！ 筋肉本舗！はいズドーン！',
+        '理想の自分を思い描いたら 今すぐ始めよ！トレーニング！イエス、マッスル！',
+        'ヤバめの現実何とかなるはず ダンベル両手にフリーウェイト！(ナイスマッチョ！)',
+        '焦りは禁物、無理しちゃ沈没 負荷のかけ方を調節！(そう、筋肉！)',
+        '限界10回ギリギリ全開！ 3セットしたらオーライ！(ナイスポーズ！)',
+        '辛いこともある筋肉道(筋肉道) モテモテボディがほしいの！ 奇麗なワタシに大変身(大変身) 見てなさい！(さい？)さい！(さい？？)',
+        'はい、サイドチェストーーー！',
+      ]
+      data = []
+      11.times do |i|
+        data << {
+          "id": i + 1,
+          "body": messages[i % messages.size],
+          "send_user": UserSerializer.new(users[rand(users.size)]).as_json,
+          "created_at": "2019-11-19 04:58:55",
+          "updated_at": "2019-11-19 04:58:55"
+        }
+      end
+      success_res(200, message: '[Mock]: 取得しました', data: data) and return
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
           post '/', to: 'direct_message_groups#create'
         end
       end
-      resources :groups, only: [:index, :show, :create]
+      resources :groups, only: [:index, :show, :create] do
+        get '/messages', to: 'group_messages#show'
+      end
     end
   end
 

--- a/docs/blueprints/api_blueprint.md
+++ b/docs/blueprints/api_blueprint.md
@@ -110,8 +110,7 @@ Muscler'sのAPI仕様書
 + body: 今日はみんなで大腿四頭筋を追い込みましょう！！ (string)
 + created_at: `2019-11-19 04:58:55` (string)
 + updated_at: `2019-11-19 04:58:55` (string)
-+ user (User)
-+ group (Group)
++ send_user (User)
 
 ### DirectMessageGroup (object)
 

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -23,9 +23,36 @@
           <h5 class="mb-2">概要</h5>
           {{ group.description }}
         </v-tab-item>
+
         <v-tab-item class="flat-background">
-          グループチャット
+          <template v-for="(item, index) in messages">
+            <v-list
+              :id="`message-${index}`"
+              :key="index"
+              three-line
+              class="pa-0 flat-background"
+            >
+              <v-list-item>
+                <v-list-item-avatar>
+                  <v-img :src="item.send_user.thumbnail"></v-img>
+                </v-list-item-avatar>
+
+                <v-list-item-content>
+                  <v-list-item-title>
+                    {{ item.send_user.nickname || 'unknown' }}
+                    <span class="grey--text text--lighten-1">
+                      {{ item.updated_at }}
+                    </span>
+                  </v-list-item-title>
+                  <v-list-item-subtitle class="d-block">
+                    {{ item.body }}
+                  </v-list-item-subtitle>
+                </v-list-item-content>
+              </v-list-item>
+            </v-list>
+          </template>
         </v-tab-item>
+
         <v-tab-item class="flat-background">
           グループメンバー
         </v-tab-item>
@@ -42,6 +69,7 @@ export default {
 
   data: () => ({
     group: null,
+    messages: null,
     tabs: ['詳細', 'チャット', 'メンバー'],
     tab: null
   }),
@@ -50,9 +78,13 @@ export default {
     const group = await $axios
       .$get(`/mock/api/groups/${params.id}`)
       .then((res) => res.data)
+    const messages = await $axios
+      .$get(`/mock/api/groups/${params.id}/messages`)
+      .then((res) => res.data)
 
     return {
-      group
+      group,
+      messages
     }
   }
 }


### PR DESCRIPTION
close #196 

# 概要

グループメッセージのタブを追加。
UIは大体でやった。

# 変更点

- グループメッセージのレスポンス構造を変更
- モックを作成

`/group_messages/_id.vue`は使わない可能性が出てきた。
なぜなら`/groups/_id.vue`の中でタブ分け表示しているため、別ページに移すと手間が増えてしまう。(技術的にはそこまで難しくないが)

# スクリーンショット

<img width="1680" alt="スクリーンショット 2019-11-26 15 30 12" src="https://user-images.githubusercontent.com/22770924/69604921-2281e900-1062-11ea-8744-66d2fea6a53a.png">
<img width="375" alt="スクリーンショット 2019-11-26 15 30 23" src="https://user-images.githubusercontent.com/22770924/69604922-2281e900-1062-11ea-9d5c-59f81b552b29.png">
