### PR TITLE
Create group and friend table

### DIFF
--- a/backend/app/models/friend.rb
+++ b/backend/app/models/friend.rb
@@ -1,0 +1,4 @@
+class Friend < ApplicationRecord
+  belongs_to :user
+  belongs_to :target ,class_name: "User", foreign_key: "target_id"
+end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,2 +1,3 @@
 class Group < ApplicationRecord
+  has_many :group_users
 end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,3 +1,4 @@
 class Group < ApplicationRecord
-  has_many :group_users
+  has_many :group_users, :dependent => :destroy
+  has_many :group_messages, :dependent => :destroy
 end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,4 +1,5 @@
 class Group < ApplicationRecord
   has_many :group_users, :dependent => :destroy
   has_many :group_messages, :dependent => :destroy
+  has_one_attached :thumbnail
 end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
-  has_many :group_users, :dependent => :destroy
+  has_many :group_users
+  has_many :users,through: :group_users, :dependent => :destroy
   has_many :group_messages, :dependent => :destroy
   has_one_attached :thumbnail
 end

--- a/backend/app/models/group_message.rb
+++ b/backend/app/models/group_message.rb
@@ -1,0 +1,4 @@
+class GroupMessage < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/backend/app/models/group_user.rb
+++ b/backend/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,11 +1,12 @@
 class User < ApplicationRecord
+  has_many :group_users
+  has_many :user_tags
+  has_many :blogs 
   has_many :friends, :dependent => :destroy
   has_many :targets,
             class_name: "Friend",
             foreign_key: :target_id,
             :dependent => :destroy
-  has_many :user_tags
-  has_many :blogs
   has_many :by_users,
             class_name: "DirectMessageGroup",
             foreign_key: :by_user_id,

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,4 +1,9 @@
 class User < ApplicationRecord
+  has_many :friends, :dependent => :destroy
+  has_many :targets,
+            class_name: "Friend",
+            foreign_key: :target_id,
+            :dependent => :destroy
   has_many :user_tags
   has_many :blogs
   has_many :by_users,

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,13 +1,20 @@
 class User < ApplicationRecord
-  has_many :group_users
+  has_many :group_users, :dependent => :destroy
   has_many :groups,through: :group_users, :dependent => :destroy
   has_many :group_messages, :dependent => :destroy
   has_many :user_tags
-  has_many :blogs 
-  has_many :friends, :dependent => :destroy
-  has_many :targets,
+  has_many :blogs
+  has_many :friends
+  has_many :target_friends,
             class_name: "Friend",
-            foreign_key: :target_id,
+            foreign_key: :target_id
+  has_many :followings,
+            through: :friends,
+            source: :target,
+            :dependent => :destroy
+  has_many :followers,
+            through: :target_friends,
+            source: :user,
             :dependent => :destroy
   has_many :by_users,
             class_name: "DirectMessageGroup",

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -5,16 +5,9 @@ class User < ApplicationRecord
   has_many :user_tags
   has_many :blogs
   has_many :friends
-  has_many :target_friends,
-            class_name: "Friend",
-            foreign_key: :target_id
   has_many :followings,
             through: :friends,
             source: :target,
-            :dependent => :destroy
-  has_many :followers,
-            through: :target_friends,
-            source: :user,
             :dependent => :destroy
   has_many :by_users,
             class_name: "DirectMessageGroup",

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  has_many :group_users, :dependent => :destroy
+  has_many :group_users
+  has_many :groups,through: :group_users, :dependent => :destroy
   has_many :group_messages, :dependent => :destroy
   has_many :user_tags
   has_many :blogs 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  has_many :group_users
+  has_many :group_users, :dependent => :destroy
+  has_many :group_messages, :dependent => :destroy
   has_many :user_tags
   has_many :blogs 
   has_many :friends, :dependent => :destroy

--- a/backend/db/migrate/20191202025218_create_friends.rb
+++ b/backend/db/migrate/20191202025218_create_friends.rb
@@ -1,0 +1,11 @@
+class CreateFriends < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friends do |t|
+      t.references :user, foreign_key: true
+      t.references :target, foreign_key: { to_table: :users }
+      t.boolean :is_pending, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20191202025218_create_friends.rb
+++ b/backend/db/migrate/20191202025218_create_friends.rb
@@ -6,6 +6,8 @@ class CreateFriends < ActiveRecord::Migration[5.2]
       t.boolean :is_pending, default: false, null: false
 
       t.timestamps
+
+      t.index [:user_id, :target_id], unique: true
     end
   end
 end

--- a/backend/db/migrate/20191202040626_create_groups.rb
+++ b/backend/db/migrate/20191202040626_create_groups.rb
@@ -1,0 +1,12 @@
+class CreateGroups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.text :description
+      t.boolean :is_public, default: false, null: false
+      t.string :tags
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20191202041204_create_group_users.rb
+++ b/backend/db/migrate/20191202041204_create_group_users.rb
@@ -1,0 +1,10 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :group_users do |t|
+      t.references :user, foreign_key: true
+      t.references :group, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20191202041828_create_group_messages.rb
+++ b/backend/db/migrate/20191202041828_create_group_messages.rb
@@ -1,0 +1,11 @@
+class CreateGroupMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :group_messages do |t|
+      t.text :body
+      t.references :user, foreign_key: true
+      t.references :group, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_025218) do
+ActiveRecord::Schema.define(version: 2019_12_02_040626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,15 @@ ActiveRecord::Schema.define(version: 2019_12_02_025218) do
     t.datetime "updated_at", null: false
     t.index ["target_id"], name: "index_friends_on_target_id"
     t.index ["user_id"], name: "index_friends_on_user_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.boolean "is_public", default: false, null: false
+    t.string "tags"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "information", force: :cascade do |t|

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2019_12_02_041828) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["target_id"], name: "index_friends_on_target_id"
+    t.index ["user_id", "target_id"], name: "index_friends_on_user_id_and_target_id", unique: true
     t.index ["user_id"], name: "index_friends_on_user_id"
   end
 

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_041204) do
+ActiveRecord::Schema.define(version: 2019_12_02_041828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,16 @@ ActiveRecord::Schema.define(version: 2019_12_02_041204) do
     t.datetime "updated_at", null: false
     t.index ["target_id"], name: "index_friends_on_target_id"
     t.index ["user_id"], name: "index_friends_on_user_id"
+  end
+
+  create_table "group_messages", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id"
+    t.bigint "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_messages_on_group_id"
+    t.index ["user_id"], name: "index_group_messages_on_user_id"
   end
 
   create_table "group_users", force: :cascade do |t|
@@ -158,6 +168,8 @@ ActiveRecord::Schema.define(version: 2019_12_02_041204) do
   add_foreign_key "direct_messages", "users", column: "send_user_id"
   add_foreign_key "friends", "users"
   add_foreign_key "friends", "users", column: "target_id"
+  add_foreign_key "group_messages", "groups"
+  add_foreign_key "group_messages", "users"
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
   add_foreign_key "information", "users"

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_27_123511) do
+ActiveRecord::Schema.define(version: 2019_12_02_025218) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,16 @@ ActiveRecord::Schema.define(version: 2019_11_27_123511) do
     t.index ["send_user_id"], name: "index_direct_messages_on_send_user_id"
   end
 
+  create_table "friends", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "target_id"
+    t.boolean "is_pending", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["target_id"], name: "index_friends_on_target_id"
+    t.index ["user_id"], name: "index_friends_on_user_id"
+  end
+
   create_table "information", force: :cascade do |t|
     t.integer "type"
     t.string "by_name"
@@ -128,6 +138,8 @@ ActiveRecord::Schema.define(version: 2019_11_27_123511) do
   add_foreign_key "direct_message_groups", "users", column: "to_user_id"
   add_foreign_key "direct_messages", "direct_message_groups"
   add_foreign_key "direct_messages", "users", column: "send_user_id"
+  add_foreign_key "friends", "users"
+  add_foreign_key "friends", "users", column: "target_id"
   add_foreign_key "information", "users"
   add_foreign_key "user_tags", "tags"
   add_foreign_key "user_tags", "users"

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_040626) do
+ActiveRecord::Schema.define(version: 2019_12_02_041204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,15 @@ ActiveRecord::Schema.define(version: 2019_12_02_040626) do
     t.index ["user_id"], name: "index_friends_on_user_id"
   end
 
+  create_table "group_users", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_users_on_group_id"
+    t.index ["user_id"], name: "index_group_users_on_user_id"
+  end
+
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -149,6 +158,8 @@ ActiveRecord::Schema.define(version: 2019_12_02_040626) do
   add_foreign_key "direct_messages", "users", column: "send_user_id"
   add_foreign_key "friends", "users"
   add_foreign_key "friends", "users", column: "target_id"
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
   add_foreign_key "information", "users"
   add_foreign_key "user_tags", "tags"
   add_foreign_key "user_tags", "users"

--- a/backend/spec/factories/friends.rb
+++ b/backend/spec/factories/friends.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :friend do
+    
+  end
+end

--- a/backend/spec/factories/group_messages.rb
+++ b/backend/spec/factories/group_messages.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :group_message do
+    
+  end
+end

--- a/backend/spec/factories/group_users.rb
+++ b/backend/spec/factories/group_users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :group_user do
+    
+  end
+end

--- a/backend/spec/factories/groups.rb
+++ b/backend/spec/factories/groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :group do
+    
+  end
+end

--- a/backend/spec/models/friend_spec.rb
+++ b/backend/spec/models/friend_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Friend, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/friend_spec.rb
+++ b/backend/spec/models/friend_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Friend, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "User association" do
+    context "belongs to user" do
+      it { should belong_to(:user) }
+    end
+
+    context "belongs to target" do
+      it { should belong_to(:target).class_name('User') }
+    end
+  end
 end

--- a/backend/spec/models/group_message_spec.rb
+++ b/backend/spec/models/group_message_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GroupMessage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/group_message_spec.rb
+++ b/backend/spec/models/group_message_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe GroupMessage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "User association" do
+    context "belongs to user" do
+      it { should belong_to(:user) }
+    end
+  end
+
+  describe " Group association" do
+    context "belongs to group" do
+      it { should belong_to(:group) }
+    end
+  end
 end

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "GroupUser association" do
+    context "has many group_users" do
+      it { should have_many(:group_users) }
+    end
+  end
+
+  describe "User association" do
+    context "has many users" do
+      it { should have_many(:users).through(:group_users).dependent(:destroy) }
+    end
+  end
+
+  describe "GroupMessage association" do
+    context "has many group_messages" do
+      it { should have_many(:group_messages).dependent(:destroy) }
+    end
+  end
 end

--- a/backend/spec/models/group_user_spec.rb
+++ b/backend/spec/models/group_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GroupUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/group_user_spec.rb
+++ b/backend/spec/models/group_user_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe GroupUser, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "User association" do
+    context "belongs to user" do
+      it { should belong_to(:user) }
+    end
+  end
+
+  describe "Group association" do
+    context "belongs to group" do
+      it { should belong_to(:group) }
+    end
+  end
 end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -62,5 +62,33 @@ RSpec.describe User, type: :model do
         expect{ @secound_user.send_users.create!(body:"hogeee",direct_message_group_id:@not_exist_dm_group_id) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
-  end  
+  end
+  
+  describe "Friend association" do
+    context "has many fridends" do
+      it { should have_many(:friends) }
+    end
+
+    context "has many followings" do
+      it { should have_many(:followings).through(:friends).source(:target).dependent(:destroy) }
+    end
+  end
+
+  describe "GroupUser association" do
+    context "has many group users" do
+      it { should have_many(:group_users).dependent(:destroy) }
+    end
+  end
+
+  describe "Group association" do
+    context "has many groups" do
+      it { should have_many(:groups).through(:group_users).dependent(:destroy) }
+    end
+  end
+
+  describe "GroupMessage association" do
+    context "has many group_messages" do
+      it { should have_many(:group_messages).dependent(:destroy) }
+    end
+  end
 end


### PR DESCRIPTION
close #233 

# 概要

Group & Friend テーブルを作成する

# 変更点

- friend tableを作成
- group tbaleを作成
- group_user tableを作成
- group_message tableを作成
- groupにサムネイルを追加
- `user.groups` で `user` が参加しているグループ一覧を取得
- `group.users` で `group` に参加しているユーザの一覧を取得
- `user.followings` とすることで `user`  がフォローしているユーザを取得
- ~`user.followers` で `user` のことをフォローしているユーザを取得~
- 各モデルのアソシエーションのテストを追加
# スクリーンショット

# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
