### PR TITLE
Add home page

### DIFF
--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -34,6 +34,10 @@
       <div slot="button-prev" class="swiper-button-prev"></div>
       <div slot="button-next" class="swiper-button-next"></div>
     </div>
+    <nuxt-link to="/user_blogs" class="d-block my-4 search-text">
+      ユーザーブログをもっと見る
+      <v-icon class="blue--text">chevron_right</v-icon>
+    </nuxt-link>
 
     <h2 class="mt-12 ml-0">新着グループ</h2>
     <v-row>
@@ -69,6 +73,10 @@
         </v-card>
       </v-col>
     </v-row>
+    <nuxt-link to="/groups" class="d-block my-4 search-text">
+      グループをもっと見る
+      <v-icon class="blue--text">chevron_right</v-icon>
+    </nuxt-link>
 
     <h2 class="mt-12 ml-0">タグ</h2>
     <v-row>

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -38,6 +38,22 @@
     <h2>新着グループ</h2>
 
     <h2>タグ</h2>
+    <v-row>
+      <v-col
+        v-for="tag in tags"
+        :key="tag.id"
+        cols="6"
+        md="3"
+        class="pa-2 cell-wrapper"
+        :to="`/home?tag=${tag.name}`"
+      >
+        <nuxt-link :to="`/home?tag=${tag.name}`" class="undecoration-link">
+          <span class="cell-body">
+            {{ tag.name }}
+          </span>
+        </nuxt-link>
+      </v-col>
+    </v-row>
   </div>
 </template>
 
@@ -80,9 +96,11 @@ export default {
 
   async asyncData({ $axios }) {
     const blogs = await $axios.$get('/mock/api/blogs').then((res) => res.data)
+    const tags = await $axios.$get('/api/tags').then((res) => res.data)
 
     return {
-      blogs
+      blogs,
+      tags
     }
   },
 
@@ -100,10 +118,36 @@ export default {
 </script>
 
 <style scoped>
+.undecoration-link {
+  text-decoration: none;
+}
+
 .search-text {
   font-weight: bold;
   font-size: 77%;
   text-decoration: none;
+}
+
+.cell-wrapper {
+  width: 25%;
+  width: -webkit-calc(25% - 10px);
+  width: calc(25% - 10px);
+  min-height: 80px;
+}
+.cell-body {
+  width: 100%;
+  height: 100%;
+  padding: 10px;
+  background: white;
+  border: solid 2px #eaeaea;
+  border-radius: 10px;
+  font-weight: bold;
+  font-size: 110%;
+  color: black;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .slide-box {

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -6,9 +6,9 @@
         label="ユーザー検索"
         placeholder="キーワードでユーザーを検索"
         hide-details
-        prepend-inner-icon="search"
         single-line
         outlined
+        class="search-placeholder"
         @keyup.enter="onSubmitSearch()"
       ></v-text-field>
       <v-btn class="ml-2" large color="primary" @click="onSubmitSearch()">
@@ -155,6 +155,10 @@ export default {
 </script>
 
 <style scoped>
+.search-placeholder {
+  font-size: 85%;
+}
+
 .undecoration-link {
   text-decoration: none;
 }

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -35,9 +35,42 @@
       <div slot="button-next" class="swiper-button-next"></div>
     </div>
 
-    <h2>新着グループ</h2>
+    <h2 class="mt-12 ml-0">新着グループ</h2>
+    <v-row>
+      <v-col v-for="group in groups" :key="group.id" cols="12" sm="6" lg="3">
+        <v-card>
+          <nuxt-link :to="{ name: 'groups-id', params: { id: group.id } }">
+            <v-img height="200" :src="group.thumbnail"></v-img>
+          </nuxt-link>
 
-    <h2>タグ</h2>
+          <v-card-title class="title pb-0">
+            <nuxt-link
+              :to="{ name: 'groups-id', params: { id: group.id } }"
+              class="undecoration-link black--text font-weight-bold"
+            >
+              {{ group.name }}
+            </nuxt-link>
+          </v-card-title>
+
+          <v-card-text>
+            <v-chip-group column>
+              <v-chip v-for="tag in group.tags" :key="tag.id" label small>
+                {{ tag.name }}
+              </v-chip>
+            </v-chip-group>
+            <div class="mb-4 grey--text text--lighten-1">
+              {{ group.created_at }}
+            </div>
+            <div
+              class="card-body-overflow"
+              v-text="group.description.slice(0, 100)"
+            ></div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <h2 class="mt-12 ml-0">タグ</h2>
     <v-row>
       <v-col
         v-for="tag in tags"
@@ -97,10 +130,14 @@ export default {
   async asyncData({ $axios }) {
     const blogs = await $axios.$get('/mock/api/blogs').then((res) => res.data)
     const tags = await $axios.$get('/api/tags').then((res) => res.data)
+    const groups = await $axios
+      .$get('/mock/api/groups')
+      .then((res) => res.data.slice(0, 4))
 
     return {
       blogs,
-      tags
+      tags,
+      groups
     }
   },
 

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -24,9 +24,11 @@
         <div v-for="(blog, key) in recentBlogs" :key="key" class="swiper-slide">
           <v-img class="slide-image" :src="blog.thumbnail"></v-img>
           <div class="slide-box">
-            <p class="slide-box-title">
-              {{ blog.title }}
-            </p>
+            <nuxt-link :to="`/user_blogs/${blog.id}`" class="undecoration-link">
+              <p class="slide-box-title">
+                {{ blog.title }}
+              </p>
+            </nuxt-link>
           </div>
         </div>
       </div>
@@ -34,7 +36,7 @@
       <div slot="button-prev" class="swiper-button-prev"></div>
       <div slot="button-next" class="swiper-button-next"></div>
     </div>
-    <nuxt-link to="/user_blogs" class="d-block my-4 search-text">
+    <nuxt-link to="/user_blogs" class="d-inline-block mt-4 search-text">
       ユーザーブログをもっと見る
       <v-icon class="blue--text">chevron_right</v-icon>
     </nuxt-link>
@@ -73,7 +75,7 @@
         </v-card>
       </v-col>
     </v-row>
-    <nuxt-link to="/groups" class="d-block search-text">
+    <nuxt-link to="/groups" class="d-inline-block search-text">
       グループをもっと見る
       <v-icon class="blue--text">chevron_right</v-icon>
     </nuxt-link>
@@ -208,7 +210,7 @@ export default {
   padding: 16px;
   box-sizing: border-box;
 }
-.slide-box > .slide-box-title {
+.slide-box .slide-box-title {
   color: white;
   width: 100%;
 }

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -73,7 +73,7 @@
         </v-card>
       </v-col>
     </v-row>
-    <nuxt-link to="/groups" class="d-block my-4 search-text">
+    <nuxt-link to="/groups" class="d-block search-text">
       グループをもっと見る
       <v-icon class="blue--text">chevron_right</v-icon>
     </nuxt-link>


### PR DESCRIPTION
close #251 

# 概要

ホーム画面にブログリンク、グループ、タグ一覧を追加

# スクリーンショット

### PC
<img width="1680" alt="スクリーンショット 2019-12-03 22 48 29" src="https://user-images.githubusercontent.com/22770924/70057610-c8b08e80-1620-11ea-9fc9-84fa02476f95.png">
<img width="1680" alt="スクリーンショット 2019-12-03 22 48 39" src="https://user-images.githubusercontent.com/22770924/70057609-c8b08e80-1620-11ea-8711-508bbf8b24a1.png">

### SmartPhone
<img width="379" alt="スクリーンショット 2019-12-03 23 01 15" src="https://user-images.githubusercontent.com/22770924/70057674-e41b9980-1620-11ea-953d-1a675c21be2f.png">
<img width="379" alt="スクリーンショット 2019-12-03 23 01 22" src="https://user-images.githubusercontent.com/22770924/70057673-e3830300-1620-11ea-9a5a-3821e286dc08.png">