### PR TITLE
Add information test data

### DIFF
--- a/backend/app/models/information.rb
+++ b/backend/app/models/information.rb
@@ -1,5 +1,5 @@
 class Information < ApplicationRecord
   belongs_to :user
 
-  enum type:  { group_invitation: 0, friend_request: 1, direct_message: 2, group_message: 3}, _prefix: true
+  enum genre:  { group_invitation: 0, friend_request: 1, direct_message: 2, group_message: 3}, _prefix: true
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -38,7 +38,7 @@ ja:
         long_term: "長期的"
 
     information:
-      type:
+      genre:
         group_invitation: 'グループ招待'
         friend_request: '友達申請'
         direct_message: 'ダイレクトメッセージ'

--- a/backend/db/migrate/20191205081949_rename_type_column_to_information.rb
+++ b/backend/db/migrate/20191205081949_rename_type_column_to_information.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToInformation < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :information, :type, :genre
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_05_042345) do
+ActiveRecord::Schema.define(version: 2019_12_05_081949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,7 +113,7 @@ ActiveRecord::Schema.define(version: 2019_12_05_042345) do
   end
 
   create_table "information", force: :cascade do |t|
-    t.integer "type"
+    t.integer "genre"
     t.string "by_name"
     t.string "link"
     t.boolean "is_read", default: false, null: false

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,5 +1,5 @@
 # 読み込みたい順番で全`db/seeds/*.rb`のbasenameを配列を定義する
-seeds = %w(users friends direct_message_groups direct_messages tags groups)
+seeds = %w(users friends direct_message_groups direct_messages tags groups information)
 
 Rails.logger.info "Load all seed files 'db/seeds/*.rb'."
 seeds.each do |seed|

--- a/backend/db/seeds/information.rb
+++ b/backend/db/seeds/information.rb
@@ -1,0 +1,19 @@
+genre_number = Information.genres.values
+first_user = User.first
+send_messages = DirectMessage.where.not(send_user_id:first_user.id)
+send_users = send_messages.map {|item| item.send_user_id}.uniq
+users = User.where(id:send_users)
+information = send_messages.map do |item|
+  {
+    genre: genre_number[2],
+    by_name: users.find {|user| user.id === item.send_user_id}.nickname,
+    link: "/direct_messages/#{item.direct_message_group_id}",
+    is_read: false,
+    user_id: first_user.id,
+  }
+end
+
+information.each do |item|
+  Information.create(item)
+  p "create Information by_name:#{item[:by_name]}, link:#{item[:link]}"
+end


### PR DESCRIPTION
close #

# 概要

通知のテストデータを作成する

# 変更点

- Informationテーブルのtypeカラム名がrailsの予約語として登録されていたため `genre` に変更
- `seeds/infoprmation.rb` を作成しInformationのテストデータを作成

# スクリーンショット

# 関連issue

- [ ] #258 

# 留意事項・参考

DMのテストデータに沿って通知のテストデータを作成したためテストデータの作成件数が少なくなっている(現状4件)
