### PR TITLE
Add dm api

### DIFF
--- a/backend/app/controllers/api/direct_message_groups_controller.rb
+++ b/backend/app/controllers/api/direct_message_groups_controller.rb
@@ -7,6 +7,15 @@ module Api
       success_res(200, message: '取得しました', data: data) and return
     end
 
+    def show
+      data = DirectMessageGroup.preload(:direct_messages, :by_user, :to_user).find(params[:id])
+      success_res(
+        200,
+        message: '取得しました',
+        data: DirectMessageGroupSerializer.new(data).as_json
+      ) and return
+    end
+
     private
 
     def make_dm_list_data
@@ -54,4 +63,4 @@ module Api
 
   end
 end
-  
+

--- a/backend/app/serializers/direct_message_group_serializer.rb
+++ b/backend/app/serializers/direct_message_group_serializer.rb
@@ -1,0 +1,22 @@
+class DirectMessageGroupSerializer < ActiveModel::Serializer
+  include DateHelper
+  has_many :direct_messages
+  belongs_to :by_user, serializer: UserSerializer
+  belongs_to :to_user, serializer: UserSerializer
+
+  attributes(
+    :id,
+    :created_at,
+    :updated_at
+  )
+
+  def created_at
+    created_date(object.created_at)
+  end
+
+  def updated_at
+    updated_date(object.updated_at)
+  end
+end
+
+

--- a/backend/app/serializers/direct_message_serializer.rb
+++ b/backend/app/serializers/direct_message_serializer.rb
@@ -1,0 +1,23 @@
+class DirectMessageSerializer < ActiveModel::Serializer
+  include DateHelper
+
+  attributes(
+    :id,
+    :body,
+    :direct_message_group_id,
+    :send_user_id,
+    :created_at,
+    :updated_at
+  )
+
+  def created_at
+    created_date(object.created_at)
+  end
+
+  def updated_at
+    updated_date(object.updated_at)
+  end
+end
+
+
+

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     scope :user do
       resources :information, only: [:index]
 
-      resources :direct_message_groups,only: [:index]
+      resources :direct_message_groups,only: [:index, :show]
 
       post '/friends', to: 'friends#requestFriend'
     end

--- a/backend/db/seeds/friends.rb
+++ b/backend/db/seeds/friends.rb
@@ -1,5 +1,5 @@
 test_user = User.first
 (2..11).each do |number|
-  test_user.friends.create(target_id: number,is_pending: false)
+  test_user.friends.create(from_user: test_user, target_id: number, is_pending: false)
   p "create friend user_id:#{test_user.id},target_id:#{number}"
 end

--- a/backend/spec/requests/direct_message_spec.rb
+++ b/backend/spec/requests/direct_message_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "DirectMessage", type: :request do
+  describe "GET /direct_message_groups/:id" do
+    context 'when logged in user' do
+      let(:from_user) { create(:user) }
+      let(:headers) { { 'Authorization' => from_user.access_token } }
+      let(:target_user) { create(:user) }
+      let(:direct_message_group) { from_user.by_users.create(to_user: target_user) }
+
+      before do
+        direct_message_group.direct_messages.create!(send_user: from_user, body: 'hello')
+        direct_message_group.direct_messages.create!(send_user: from_user, body: 'world')
+        direct_message_group.direct_messages.create!(send_user: target_user, body: '!')
+      end
+
+      it 'return direct_messaegs in direct_message_group' do
+        get api_direct_message_group_path(direct_message_group.id), headers: headers
+        expect(response).to have_http_status(200)
+        body = JSON.parse(response.body)
+        p body
+      end
+
+      it 'return direct messages' do
+        get api_direct_message_group_path(direct_message_group.id), headers: headers
+        body = JSON.parse(response.body)
+        expect(body['data']['direct_messages'].count).to eq 3
+      end
+    end
+  end
+end

--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <h1>{{ getOpponent.nickname }}さんとのDM</h1>
+    <v-btn to="/direct_messages" class="mb-2" text>
+      <v-icon>keyboard_arrow_left</v-icon>
+      戻る
+    </v-btn>
+    <h1 class="mb-6">{{ getOpponent.nickname }}さん</h1>
     <v-snackbar
       v-model="disconnectedChannel"
       :color="errMsgType"
@@ -12,7 +16,6 @@
       <v-btn dark text @click="disconnectedChannel = false">CLOSE</v-btn>
     </v-snackbar>
 
-    <v-btn to="/direct_messages" class="mb-4" text small>戻る</v-btn>
     <v-card max-width="450" class="mx-auto chat-card">
       <div class="overflow-y-auto messages">
         <template v-for="(item, index) in directMessages">

--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -101,7 +101,7 @@ export default {
 
   async asyncData({ $axios, params }) {
     const dmGroup = await $axios
-      .$get(`/mock/api/user/direct_message_groups/${params.id}`)
+      .$get(`/api/user/direct_message_groups/${params.id}`)
       .then((res) => res.data)
       .catch(() => null)
     const directMessages = dmGroup ? dmGroup.direct_messages : null

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -72,8 +72,11 @@ export default {
 
   async asyncData({ $axios }) {
     const groups = await $axios
-      .$get('api/user/direct_message_groups')
-      .then((res) => res.data)
+      .$get('/api/user/direct_message_groups')
+      .then((res) => {
+        console.log(res)
+        return res.data
+      })
       .catch(() => [])
 
     return {

--- a/frontend/pages/direct_messages/index.vue
+++ b/frontend/pages/direct_messages/index.vue
@@ -2,7 +2,7 @@
   <div>
     <h1>DM一覧</h1>
 
-    <v-card max-width="450" class="mx-auto">
+    <v-card max-width="450" min-height="720" class="mx-auto">
       <template v-for="(item, index) in computedDirectMessageGroups">
         <v-list :key="index" three-line>
           <v-list-item :to="`/direct_messages/${item.id}`">
@@ -75,7 +75,7 @@ export default {
       .$get('/api/user/direct_message_groups')
       .then((res) => {
         console.log(res)
-        return res.data
+        return res.data !== null ? res.data : []
       })
       .catch(() => [])
 

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <v-btn to="/groups" class="mb-4" text small>戻る</v-btn>
+    <v-btn to="/groups" class="mb-4" text>
+      <v-icon>keyboard_arrow_left</v-icon>
+      戻る
+    </v-btn>
     <p class="grey--text text--lighten-1">{{ group.created_at }}作成</p>
     <v-flex>
       <h1>「{{ group.name }}」グループ</h1>


### PR DESCRIPTION
close #280 

# 概要

DM詳細APIを実装

# 変更点

- DM詳細APIを実装
- DMGとDMのserializer
- FriendSeederを修正
- APIのテストを追加

# スクリーンショット

<img width="376" alt="スクリーンショット 2019-12-11 21 54 01" src="https://user-images.githubusercontent.com/22770924/70623177-e1dcbf00-1c60-11ea-99e7-d6b91a897b73.png">
