### PR TITLE
Add group members

### DIFF
--- a/backend/app/controllers/api/group_members_controller.rb
+++ b/backend/app/controllers/api/group_members_controller.rb
@@ -1,10 +1,7 @@
 class Api::GroupMembersController < ApplicationController
   def show
-    group_members = Group.find(params[:group_id]).users
-    data = ActiveModel::Serializer::CollectionSerializer.new(
-      group_members,
-      each_serializer: UserSerializer
-    ).as_json
+    group_members = Group.preload(:users).find(params[:group_id])
+    data = GroupMemberSerializer.new(group_members).as_json
     success_res(200, message: 'グループメンバーが見つかりました', data: data) and return
   end
 end

--- a/backend/app/controllers/api/group_members_controller.rb
+++ b/backend/app/controllers/api/group_members_controller.rb
@@ -1,6 +1,6 @@
 class Api::GroupMembersController < ApplicationController
   def show
-    group_members = Group.find(params[:id]).users
+    group_members = Group.find(params[:group_id]).users
     data = ActiveModel::Serializer::CollectionSerializer.new(
       group_members,
       each_serializer: UserSerializer

--- a/backend/app/controllers/api/group_members_controller.rb
+++ b/backend/app/controllers/api/group_members_controller.rb
@@ -1,0 +1,10 @@
+class Api::GroupMembersController < ApplicationController
+  def show
+    group_members = Group.find(params[:id]).users
+    data = ActiveModel::Serializer::CollectionSerializer.new(
+      group_members,
+      each_serializer: UserSerializer
+    ).as_json
+    success_res(200, message: 'グループメンバーが見つかりました', data: data) and return
+  end
+end

--- a/backend/app/serializers/group_member_serializer.rb
+++ b/backend/app/serializers/group_member_serializer.rb
@@ -1,0 +1,34 @@
+class GroupMemberSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+  include DateHelper
+  has_many :users
+
+  attributes(
+    :id,
+    :name,
+    :description,
+    :is_public,
+    :tags,
+    :thumbnail,
+    :created_at,
+    :updated_at
+  )
+
+  def thumbnail
+    if object.thumbnail.attached?
+      url_for(object.thumbnail)
+    else
+      root_url + "images/noimage.png"
+    end
+  end
+
+  def created_at
+    created_date(object.created_at)
+  end
+
+  def updated_at
+    updated_date(object.updated_at)
+  end
+end
+
+

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -53,12 +53,13 @@ Rails.application.routes.draw do
     end
 
     resources :groups, only: [:index, :show] do
+      get '/users', to:'group_members#show'
+
       member do
         post :join
       end
-    end
 
-    resources :group_members, only: [:show]
+    end
 
     get '/debug_login', to:'debug#index'
   end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :group_members, only: [:show]
+
     get '/debug_login', to:'debug#index'
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,5 +1,5 @@
 # 読み込みたい順番で全`db/seeds/*.rb`のbasenameを配列を定義する
-seeds = %w(users friends direct_message_groups direct_messages tags groups information blogs blog_tags)
+seeds = %w(users friends direct_message_groups direct_messages tags groups group_members information blogs blog_tags)
 
 Rails.logger.info "Load all seed files 'db/seeds/*.rb'."
 seeds.each do |seed|

--- a/backend/db/seeds/group_members.rb
+++ b/backend/db/seeds/group_members.rb
@@ -1,0 +1,7 @@
+Group.all.each do |item|
+  users = User.pluck(:id).sample(3)
+  users.each do |user_id|
+    GroupUser.create(user_id: user_id,group_id: item.id)
+  end
+  p "create group users user_id:#{users}, group_id:#{item.id}"
+end

--- a/backend/spec/requests/group_members_api_spec.rb
+++ b/backend/spec/requests/group_members_api_spec.rb
@@ -4,7 +4,7 @@ describe 'group members api', type: :request do
   describe 'GET #show' do
     context 'not logged in user' do
       it 'return status code 401' do
-        get api_group_member_path(0)
+        get api_group_users_path(0)
         expect(response.status).to eq 401
       end
     end
@@ -23,7 +23,7 @@ describe 'group members api', type: :request do
       end  
 
       it 'return group members data' do
-        get api_group_member_path(@group.id),headers: @headers
+        get api_group_users_path(@group.id),headers: @headers
         expect(response).to have_http_status(200)
         data = JSON.parse(response.body)
         expect(data['message']).to eq 'グループメンバーが見つかりました'

--- a/backend/spec/requests/group_members_api_spec.rb
+++ b/backend/spec/requests/group_members_api_spec.rb
@@ -27,7 +27,7 @@ describe 'group members api', type: :request do
         expect(response).to have_http_status(200)
         data = JSON.parse(response.body)
         expect(data['message']).to eq 'グループメンバーが見つかりました'
-        expect(data['data'].count).to eq 3
+        expect(data['data']['users'].count).to eq 3
       end
     end
   end

--- a/backend/spec/requests/group_members_api_spec.rb
+++ b/backend/spec/requests/group_members_api_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'group members api', type: :request do
+  describe 'GET #show' do
+    context 'not logged in user' do
+      it 'return status code 401' do
+        get api_group_member_path(0)
+        expect(response.status).to eq 401
+      end
+    end
+
+    context 'when search group member by group_id' do
+      before do
+        access_token = create(:user).access_token
+        @headers = {
+          'Authorization' => access_token
+        }
+        @group = create(:group)
+        users = create_list(:user,3)
+        users.each do |user|
+          GroupUser.create!(user_id:user.id,group_id:@group.id)
+        end
+      end  
+
+      it 'return group members data' do
+        get api_group_member_path(@group.id),headers: @headers
+        expect(response).to have_http_status(200)
+        data = JSON.parse(response.body)
+        expect(data['message']).to eq 'グループメンバーが見つかりました'
+        expect(data['data'].count).to eq 3
+      end
+    end
+  end
+end

--- a/backend/spec/routing/group_members_routing_spec.rb
+++ b/backend/spec/routing/group_members_routing_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Api::GroupMembersController, type: :routing do
+  describe "routing" do
+    it "routes to #show" do
+      expect(:get => "/api/group_members/1").to route_to("api/group_members#show", id: "1", format: :json)
+    end
+  end
+end
+

--- a/backend/spec/routing/group_members_routing_spec.rb
+++ b/backend/spec/routing/group_members_routing_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::GroupMembersController, type: :routing do
   describe "routing" do
     it "routes to #show" do
-      expect(:get => "/api/group_members/1").to route_to("api/group_members#show", id: "1", format: :json)
+      expect(:get => "/api/groups/1/users").to route_to("api/group_members#show", group_id: "1", format: :json)
     end
   end
 end

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -112,7 +112,7 @@ export default {
       .$get(`/mock/api/groups/${params.id}/messages`)
       .then((res) => res.data)
     const members = await $axios
-      .$get(`/api/group_members/${params.id}`)
+      .$get(`/api/groups/${params.id}/users`)
       .then((res) => res.data)
     console.log(members)
     return {

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -58,7 +58,26 @@
         </v-tab-item>
 
         <v-tab-item class="flat-background">
-          グループメンバー
+          <template v-for="(item, index) in members">
+            <v-list
+              :id="`member-${index}`"
+              :key="index"
+              three-line
+              class="pa-0 flat-background"
+            >
+              <v-list-item :to="{ name: 'users-id', params: { id: item.id } }">
+                <v-list-item-avatar>
+                  <v-img :src="item.thumbnail"></v-img>
+                </v-list-item-avatar>
+
+                <v-list-item-content>
+                  <v-list-item-title>
+                    {{ item.nickname || 'unknown' }}
+                  </v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+            </v-list>
+          </template>
         </v-tab-item>
       </v-tabs-items>
     </v-tabs>
@@ -80,6 +99,7 @@ export default {
   data: () => ({
     group: null,
     messages: null,
+    members: null,
     tabs: ['詳細', 'チャット', 'メンバー'],
     tab: null
   }),
@@ -91,10 +111,14 @@ export default {
     const messages = await $axios
       .$get(`/mock/api/groups/${params.id}/messages`)
       .then((res) => res.data)
-
+    const members = await $axios
+      .$get(`/api/group_members/${params.id}`)
+      .then((res) => res.data)
+    console.log(members)
     return {
       group,
-      messages
+      messages,
+      members
     }
   }
 }

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -113,7 +113,7 @@ export default {
       .then((res) => res.data)
     const members = await $axios
       .$get(`/api/groups/${params.id}/users`)
-      .then((res) => res.data)
+      .then((res) => res.data.users)
     console.log(members)
     return {
       group,


### PR DESCRIPTION
close #286 

# 概要

グループメンバを取得してフロントの画面にデータを反映させる

# 変更点

- GroupMemberAPIを作成してグループに参加しrているユーザを取得
- `groups/_id/index.vue` にメンバーを表示させる処理を記述
- メンバーに表示されているユーザをクリックするとユーザ詳細画面に遷移する

# スクリーンショット
<img width="1440" alt="スクリーンショット 2019-12-12 14 17 54" src="https://user-images.githubusercontent.com/44107494/70684745-86571380-1cea-11ea-8999-da8005fe4c80.png">


# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
