### PR TITLE
Revert i18n serializer

### DIFF
--- a/backend/app/serializers/loggedin_user_serializer.rb
+++ b/backend/app/serializers/loggedin_user_serializer.rb
@@ -27,16 +27,4 @@ class LoggedinUserSerializer < ActiveModel::Serializer
       root_url + "images/noimage.png"
     end
   end
-
-  def gender
-    object.gender_i18n
-  end
-
-  def figure
-    object.figure_i18n
-  end
-
-  def seriousness
-    object.seriousness_i18n
-  end
 end


### PR DESCRIPTION
`pages/auth/settings.vue`の構成上、LoggedinSerializerの日本語化が原因でバグが発生していた模様。
明日を乗り切るために一旦ログインユーザーのみi18n化を解除する。

ログインユーザーをそのまま表示するタイミングがないので、これによるデメリットは今の所ないと思われる。