### PR TITLE
[Fix]Link color

### DIFF
--- a/frontend/pages/TheInformation.vue
+++ b/frontend/pages/TheInformation.vue
@@ -25,22 +25,3 @@ export default {
   }
 }
 </script>
-<style>
-.img-small {
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-}
-.no-wrap {
-  float: left;
-}
-.text-position {
-  margin-left: 80px;
-  margin-top: 20px;
-  color: black;
-}
-.link-color:hover {
-  background-color: #eeeeee;
-  border-radius: 15px;
-}
-</style>

--- a/frontend/pages/TheInformation.vue
+++ b/frontend/pages/TheInformation.vue
@@ -25,3 +25,26 @@ export default {
   }
 }
 </script>
+<style scoped>
+.img-small {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+}
+.no-wrap {
+  float: left;
+}
+.text-position {
+  margin-left: 80px;
+  margin-top: 20px;
+  color: black;
+}
+a:link {
+  text-decoration: none;
+  color: black;
+}
+.link-color:hover {
+  background-color: #eeeeee;
+  border-radius: 15px;
+}
+</style>

--- a/frontend/pages/TheInformation.vue
+++ b/frontend/pages/TheInformation.vue
@@ -7,7 +7,7 @@
           <span>
             <v-img class="img-small no-wrap" :src="info.thumbnail" />
             <h4 align="left" class="text-position">
-              {{ info.by_name }}から{{ info.type }}が届きました。
+              {{ info.by_name }}から{{ info.genre }}が届きました。
             </h4>
           </span>
         </nuxt-link>

--- a/frontend/pages/TheInformation.vue
+++ b/frontend/pages/TheInformation.vue
@@ -1,22 +1,15 @@
 <!-- 通知 -->
 <template>
   <v-container>
-    <v-row v-for="info in infos" :key="info.id">
-      <v-col cols="3">
-        <nuxt-link :to="{ name: 'infos-id', params: { id: info.id } }">
-          <v-img
-            class="img-small"
-            :src="info.thumbnail"
-            alt="Avatar"
-            align="middle"
-          />
-        </nuxt-link>
-      </v-col>
-      <v-col cols="9">
-        <nuxt-link :to="{ name: 'infos-id', params: { id: info.id } }">
-          <font size="3">
-            {{ info.by_name }}から {{ info.type }}が届きました。</font
-          >
+    <v-row v-for="info in notification" :key="info.id">
+      <v-col cols="12" class="link-color">
+        <nuxt-link :to="{ name: 'notification-id', params: { id: info.id } }">
+          <span>
+            <v-img class="img-small no-wrap" :src="info.thumbnail" />
+            <h4 align="left" class="text-position">
+              {{ info.by_name }}から{{ info.type }}が届きました。
+            </h4>
+          </span>
         </nuxt-link>
       </v-col>
     </v-row>
@@ -25,7 +18,7 @@
 <script>
 export default {
   props: {
-    infos: {
+    notification: {
       type: Object,
       default: null
     }
@@ -37,5 +30,17 @@ export default {
   width: 60px;
   height: 60px;
   border-radius: 50%;
+}
+.no-wrap {
+  float: left;
+}
+.text-position {
+  margin-left: 80px;
+  margin-top: 20px;
+  color: black;
+}
+.link-color:hover {
+  background-color: #eeeeee;
+  border-radius: 15px;
 }
 </style>

--- a/frontend/pages/TheJoingroup.vue
+++ b/frontend/pages/TheJoingroup.vue
@@ -28,7 +28,7 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 .img-size {
   width: 121px;
   height: 121px;

--- a/frontend/pages/TheJoingroup.vue
+++ b/frontend/pages/TheJoingroup.vue
@@ -33,4 +33,12 @@ export default {
   width: 121px;
   height: 121px;
 }
+a:link {
+  text-decoration: none;
+  color: black;
+}
+.link-color:hover {
+  background-color: #eeeeee;
+  border-radius: 15px;
+}
 </style>

--- a/frontend/pages/TheJoingroup.vue
+++ b/frontend/pages/TheJoingroup.vue
@@ -3,7 +3,12 @@
   <div align="center">
     <v-container>
       <v-row>
-        <v-col v-for="group in joingroup" :key="group.id" cols="6">
+        <v-col
+          v-for="group in groups"
+          :key="group.id"
+          class="link-color"
+          cols="6"
+        >
           <nuxt-link :to="{ name: 'groups-id', params: { id: group.id } }">
             <v-img :src="group.thumbnail" class="img-size" />
             <h4>{{ group.name }}</h4>
@@ -16,7 +21,7 @@
 <script>
 export default {
   props: {
-    joingroup: {
+    groups: {
       type: Object,
       default: null
     }
@@ -27,6 +32,5 @@ export default {
 .img-size {
   width: 121px;
   height: 121px;
-  border-radius: 50%;
 }
 </style>

--- a/frontend/pages/TheRecommenduser.vue
+++ b/frontend/pages/TheRecommenduser.vue
@@ -28,7 +28,7 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 .img-small {
   width: 60px;
   height: 60px;

--- a/frontend/pages/TheRecommenduser.vue
+++ b/frontend/pages/TheRecommenduser.vue
@@ -4,7 +4,7 @@
     <v-container>
       <v-row>
         <v-col
-          v-for="recommend in recommended"
+          v-for="recommend in recommends"
           :key="recommend.id"
           class="link-color"
           cols="6"
@@ -21,7 +21,7 @@
 <script>
 export default {
   props: {
-    recommended: {
+    recommends: {
       type: Object,
       default: null
     }
@@ -29,9 +29,17 @@ export default {
 }
 </script>
 <style scoped>
-.img-small {
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
+.img-size {
+  width: 121px;
+  height: 121px;
+  border-radius: 4px;
+}
+a:link {
+  text-decoration: none;
+  color: black;
+}
+.link-color:hover {
+  background-color: #eeeeee;
+  border-radius: 15px;
 }
 </style>

--- a/frontend/pages/TheRecommenduser.vue
+++ b/frontend/pages/TheRecommenduser.vue
@@ -3,7 +3,12 @@
   <div align="center">
     <v-container>
       <v-row>
-        <v-col v-for="recommend in recommended" :key="recommend.id" cols="6">
+        <v-col
+          v-for="recommend in recommended"
+          :key="recommend.id"
+          class="link-color"
+          cols="6"
+        >
           <nuxt-link :to="{ name: 'users-id', params: { id: recommend.id } }">
             <v-img :src="recommend.thumbnail" class="img-size" />
             <h4>{{ recommend.nickname }}</h4>

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -19,7 +19,9 @@
                   <v-col
                     v-for="group in limitedGroups"
                     :key="group.id"
-                    cols="3"
+                    cols="6"
+                    xs="3"
+                    sm="3"
                     class="link-color"
                   >
                     <nuxt-link
@@ -67,7 +69,9 @@
                   <v-col
                     v-for="recommend in limitedRecommendusers"
                     :key="recommend.id"
-                    cols="3"
+                    cols="6"
+                    xs="3"
+                    sm="3"
                     class="link-color"
                   >
                     <nuxt-link
@@ -89,10 +93,10 @@
           </div>
         </v-tab-item>
         <v-tab-item>
-          <TheJoingroup :joingroup="groups" />
+          <TheJoingroup :groups="groups" />
         </v-tab-item>
         <v-tab-item>
-          <TheInformation :infos="infos" />
+          <TheInformation :notification="notification" />
         </v-tab-item>
         <v-tab-item>
           <TheRecommenduser :recommended="recommended" />
@@ -124,7 +128,7 @@ export default {
       return this.groups.slice(0, 4)
     },
     limitedInformation() {
-      return this.infos.slice(0, 3)
+      return this.notification.slice(0, 3)
     },
     limitedRecommendusers() {
       return this.recommended.slice(0, 4)
@@ -136,13 +140,13 @@ export default {
     const recommended = await $axios
       .$get(`/api/users/recommended_users`)
       .then((res) => res.data)
-    const infos = await $axios
+    const notification = await $axios
       .$get(`/mock/api/user/information`)
       .then((res) => res.data)
     return {
       groups,
       recommended,
-      infos
+      notification
     }
   }
 }

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -150,7 +150,7 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 h2 {
   margin-left: 20px;
 }

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -5,7 +5,7 @@
         v-model="tab"
         centered
         background-color="white"
-        color="deep-purple accent-4"
+        color="#ff9d00"
         right
       >
         <v-tab v-for="item in items" :key="item">{{ item }}</v-tab>
@@ -18,7 +18,8 @@
                   <v-col
                     v-for="group in limitedGroups"
                     :key="group.id"
-                    cols="6"
+                    cols="3"
+                    class="link-color"
                   >
                     <nuxt-link
                       :to="{ name: 'groups-id', params: { id: group.id } }"
@@ -35,8 +36,21 @@
               <h2 align="left">通知</h2>
               <v-container>
                 <v-row v-for="info in limitedInformation" :key="info.id">
-                  <v-col cols="3">
+                  <v-col cols="12" class="link-color">
                     <nuxt-link
+                      :to="{ name: 'infos-id', params: { id: info.id } }"
+                    >
+                      <span>
+                        <v-img
+                          class="img-small no-wrap"
+                          :src="info.thumbnail"
+                        />
+                        <h4 align="left" class="text-position">
+                          {{ info.by_name }}から{{ info.type }}が届きました。
+                        </h4>
+                      </span>
+                    </nuxt-link>
+                    <!-- <nuxt-link
                       :to="{ name: 'infos-id', params: { id: info.id } }"
                     >
                       <v-img
@@ -51,11 +65,13 @@
                     <nuxt-link
                       :to="{ name: 'infos-id', params: { id: info.id } }"
                     >
-                      <font size="3"
-                        >{{ info.by_name }}から
-                        {{ info.type }}が届きました。</font
-                      >
-                    </nuxt-link>
+                      <div align="left">
+                        <font size="3"
+                          >{{ info.by_name }}から
+                          {{ info.type }}が届きました。</font
+                        >
+                      </div>
+                    </nuxt-link> -->
                   </v-col>
                 </v-row>
                 <v-row>
@@ -72,7 +88,8 @@
                   <v-col
                     v-for="recommend in limitedRecommendusers"
                     :key="recommend.id"
-                    cols="6"
+                    cols="3"
+                    class="link-color"
                   >
                     <nuxt-link
                       :to="{
@@ -125,13 +142,13 @@ export default {
   },
   computed: {
     limitedGroups() {
-      return this.groups.slice(0, 2)
+      return this.groups.slice(0, 4)
     },
     limitedInformation() {
       return this.infos.slice(0, 3)
     },
     limitedRecommendusers() {
-      return this.recommended.slice(0, 2)
+      return this.recommended.slice(0, 4)
     }
   },
   async asyncData({ $axios, store }) {
@@ -162,6 +179,22 @@ h2 {
 .img-size {
   width: 121px;
   height: 121px;
-  border-radius: 50%;
+  border-radius: 4px;
+}
+a:link {
+  text-decoration: none;
+  color: black;
+}
+.link-color:hover {
+  background-color: #eeeeee;
+  border-radius: 15px;
+}
+.no-wrap {
+  float: left;
+}
+.text-position {
+  margin-left: 80px;
+  margin-top: 20px;
+  color: black;
 }
 </style>

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -8,6 +8,7 @@
         color="#ff9d00"
         right
       >
+        <!-- TODO: レスポンシブに対応する -->
         <v-tab v-for="item in items" :key="item">{{ item }}</v-tab>
         <v-tab-item>
           <div>
@@ -50,28 +51,6 @@
                         </h4>
                       </span>
                     </nuxt-link>
-                    <!-- <nuxt-link
-                      :to="{ name: 'infos-id', params: { id: info.id } }"
-                    >
-                      <v-img
-                        class="img-small"
-                        :src="info.thumbnail"
-                        alt="Avatar"
-                        align="middle"
-                      />
-                    </nuxt-link>
-                  </v-col>
-                  <v-col cols="9">
-                    <nuxt-link
-                      :to="{ name: 'infos-id', params: { id: info.id } }"
-                    >
-                      <div align="left">
-                        <font size="3"
-                          >{{ info.by_name }}から
-                          {{ info.type }}が届きました。</font
-                        >
-                      </div>
-                    </nuxt-link> -->
                   </v-col>
                 </v-row>
                 <v-row>
@@ -151,6 +130,7 @@ export default {
       return this.recommended.slice(0, 4)
     }
   },
+  /* TODO: APIを帰る */
   async asyncData({ $axios, store }) {
     const groups = await $axios.$get('/mock/api/groups').then((res) => res.data)
     const recommended = await $axios

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -41,7 +41,7 @@
                 <v-row v-for="info in limitedInformation" :key="info.id">
                   <v-col cols="12" class="link-color">
                     <nuxt-link
-                      :to="{ name: 'infos-id', params: { id: info.id } }"
+                      :to="{ name: 'notification-id', params: { id: info.id } }"
                     >
                       <span>
                         <v-img
@@ -49,7 +49,7 @@
                           :src="info.thumbnail"
                         />
                         <h4 align="left" class="text-position">
-                          {{ info.by_name }}から{{ info.type }}が届きました。
+                          {{ info.by_name }}から{{ info.genre }}が届きました。
                         </h4>
                       </span>
                     </nuxt-link>
@@ -134,14 +134,13 @@ export default {
       return this.recommended.slice(0, 4)
     }
   },
-  /* TODO: APIを帰る */
   async asyncData({ $axios, store }) {
-    const groups = await $axios.$get('/mock/api/groups').then((res) => res.data)
+    const groups = await $axios.$get('/api/groups').then((res) => res.data)
     const recommended = await $axios
       .$get(`/api/users/recommended_users`)
       .then((res) => res.data)
     const notification = await $axios
-      .$get(`/mock/api/user/information`)
+      .$get(`/api/user/information`)
       .then((res) => res.data)
     return {
       groups,

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -8,7 +8,6 @@
         color="#ff9d00"
         right
       >
-        <!-- TODO: レスポンシブに対応する -->
         <v-tab v-for="item in items" :key="item">{{ item }}</v-tab>
         <v-tab-item>
           <div>

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -99,7 +99,7 @@
           <TheInformation :notification="notification" />
         </v-tab-item>
         <v-tab-item>
-          <TheRecommenduser :recommended="recommended" />
+          <TheRecommenduser :recommends="recommends" />
         </v-tab-item>
       </v-tabs>
     </v-card>
@@ -131,12 +131,12 @@ export default {
       return this.notification.slice(0, 3)
     },
     limitedRecommendusers() {
-      return this.recommended.slice(0, 4)
+      return this.recommends.slice(0, 4)
     }
   },
   async asyncData({ $axios, store }) {
     const groups = await $axios.$get('/api/groups').then((res) => res.data)
-    const recommended = await $axios
+    const recommends = await $axios
       .$get(`/api/users/recommended_users`)
       .then((res) => res.data)
     const notification = await $axios
@@ -144,7 +144,7 @@ export default {
       .then((res) => res.data)
     return {
       groups,
-      recommended,
+      recommends,
       notification
     }
   }


### PR DESCRIPTION
close #294 

# 概要
mypageの変更

# 変更点
- グループとおすすめユーザーを増やした。(4項目)
-  通知の表示方法を変更した。
- リンクカラーを黒に統一
- カードのタブの色をヘッダーと一緒にした。
- カーソルを合わせるとホバーでバックグラウンドカラーが出るようにした。
- propsの名称修正
- TheNotificationの表示方法を変更した。(mypageと一緒)

# スクリーンショット
- カードタブと参加中のグループ
<img width="726" alt="スクリーンショット 0001-12-13 午後1 10 40" src="https://user-images.githubusercontent.com/30668284/70768894-9df5d100-1daa-11ea-8054-4fe9cce5668b.png">

- 通知
<img width="721" alt="スクリーンショット 0001-12-13 午後1 10 45" src="https://user-images.githubusercontent.com/30668284/70768913-b960dc00-1daa-11ea-92a7-452b0e50aa40.png">

- おすすめユーザー
<img width="721" alt="スクリーンショット 0001-12-13 午後1 10 50" src="https://user-images.githubusercontent.com/30668284/70768921-c382da80-1daa-11ea-9b7d-ae5952757cfe.png">

-レスポンシブの対応
参加中のグループ
<img width="293" alt="スクリーンショット 0001-12-13 午後2 55 30" src="https://user-images.githubusercontent.com/30668284/70772712-ba006f00-1db8-11ea-873c-f0635cd0db84.png">

おすすめユーザー
<img width="305" alt="スクリーンショット 0001-12-13 午後2 55 37" src="https://user-images.githubusercontent.com/30668284/70772728-c684c780-1db8-11ea-8918-4511904cbe1d.png">

# 留意事項・参考
- ~APIのアクセス先を変えてない。~
- ~レスポンシブを考慮してない~
