### PR TITLE
[Add] setting save button page under

### DIFF
--- a/frontend/pages/auth/setting.vue
+++ b/frontend/pages/auth/setting.vue
@@ -10,7 +10,6 @@
         <v-icon small>edit</v-icon>保存
       </v-btn>
     </v-layout>
-
     <div class="mb-5">
       <img
         v-if="thumbnailSrc"
@@ -114,6 +113,11 @@
       label="体脂肪率"
       :disabled="disabled"
     ></v-text-field>
+    <v-layout class="justify-center">
+      <v-btn class="my-4 ml-2" tile color="primary" @click="submitUserEdit">
+        <v-icon small>edit</v-icon>保存
+      </v-btn>
+    </v-layout>
   </div>
 </template>
 


### PR DESCRIPTION
close #297 

# 概要
ページの下に保存ボタンを貼ってみた

# 変更点
ページの下に保存ボタンを貼ってみた

- 変更内容
ページの下に保存ボタンを貼ってみた

右下にscreenshotのアイコン出てるけど気にしないように

# スクリーンショット

<img width="1305" alt="スクリーンショット 2019-12-13 13 46 46" src="https://user-images.githubusercontent.com/43775946/70770133-8bca6180-1daf-11ea-921c-c46129bbf3b0.png">

<img width="1305" alt="スクリーンショット 2019-12-13 13 46 50" src="https://user-images.githubusercontent.com/43775946/70770137-8e2cbb80-1daf-11ea-95c0-4e79fe3fa654.png">

# 関連issue

- [ ] #297 
