### PR TITLE
[Change] create group button design

### DIFF
--- a/frontend/pages/auth/setting.vue
+++ b/frontend/pages/auth/setting.vue
@@ -10,7 +10,6 @@
         <v-icon small>edit</v-icon>保存
       </v-btn>
     </v-layout>
-
     <div class="mb-5">
       <img
         v-if="thumbnailSrc"
@@ -114,6 +113,11 @@
       label="体脂肪率"
       :disabled="disabled"
     ></v-text-field>
+    <v-layout class="justify-center">
+      <v-btn class="my-4 ml-2" tile color="primary" @click="submitUserEdit">
+        <v-icon small>edit</v-icon>保存
+      </v-btn>
+    </v-layout>
   </div>
 </template>
 

--- a/frontend/pages/groups/index.vue
+++ b/frontend/pages/groups/index.vue
@@ -3,8 +3,9 @@
     <div class="d-flex">
       <h1>グループ一覧</h1>
       <v-spacer></v-spacer>
-      <v-btn fab dark small color="#ffac12" to="/groups/new">
+      <v-btn rounded small color="#ffac12" dark to="/groups/new">
         <v-icon dark>mdi-plus</v-icon>
+        グループ作成
       </v-btn>
     </div>
 

--- a/frontend/pages/groups/index.vue
+++ b/frontend/pages/groups/index.vue
@@ -3,7 +3,7 @@
     <div class="d-flex">
       <h1>グループ一覧</h1>
       <v-spacer></v-spacer>
-      <v-btn rounded small color="#ffac12" dark to="/groups/new">
+      <v-btn small color="#ffac12" class="pa-5" dark to="/groups/new">
         <v-icon dark>mdi-plus</v-icon>
         グループ作成
       </v-btn>

--- a/frontend/pages/search/index.vue
+++ b/frontend/pages/search/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn to="/groups" class="mb-4" text>
+    <v-btn to="/home" class="mb-4" text>
       <v-icon>keyboard_arrow_left</v-icon>
       戻る
     </v-btn>

--- a/frontend/pages/search/index.vue
+++ b/frontend/pages/search/index.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <v-btn to="/groups" class="mb-4" text>
+      <v-icon>keyboard_arrow_left</v-icon>
+      戻る
+    </v-btn>
     <v-layout justify-center>
       <v-form>
         <div class="container">


### PR DESCRIPTION
close #307 

# 概要
グループ作成ボタンのデザイン変更

右と左に＋アイコンを置いた場合のデザイン書いたけどどっちも微妙に見える。
アイデアとかこれでいいならリアクション欲しい

# 変更点
グループ作成ボタンのデザイン変更

- 変更内容
グループ作成ボタンのデザイン変更

# スクリーンショット

（今はこっちにしてpushしている）

<img width="1401" alt="スクリーンショット 2019-12-13 14 01 11" src="https://user-images.githubusercontent.com/43775946/70770631-7eae7200-1db1-11ea-8ef5-fbe53f1d3da0.png">

<img width="1401" alt="スクリーンショット 2019-12-13 14 01 36" src="https://user-images.githubusercontent.com/43775946/70770635-80783580-1db1-11ea-9c6a-e5fc79ae5dfa.png">

# 関連issue

- [ ] #307 
