### PR TITLE
[Change] more view link design

### DIFF
--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -80,7 +80,7 @@
         </v-card>
       </v-col>
     </v-row>
-    <nuxt-link to="/groups" class="d-inline-block search-text">
+    <nuxt-link to="/groups" class="d-inline-block search-text subtitle-1">
       グループをもっと見る
       <v-icon class="blue--text">chevron_right</v-icon>
     </nuxt-link>

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -36,7 +36,7 @@
       <div slot="button-prev" class="swiper-button-prev"></div>
       <div slot="button-next" class="swiper-button-next"></div>
     </div>
-    <nuxt-link to="/groups" class="d-inline-block search-text subtitle-1">
+    <nuxt-link to="/user_blogs" class="d-inline-block search-text subtitle-1">
       ユーザーブログをもっと見る
       <v-icon class="blue--text">chevron_right</v-icon>
     </nuxt-link>

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -36,7 +36,7 @@
       <div slot="button-prev" class="swiper-button-prev"></div>
       <div slot="button-next" class="swiper-button-next"></div>
     </div>
-    <nuxt-link to="/user_blogs" class="d-inline-block mt-4 search-text">
+    <nuxt-link to="/groups" class="d-inline-block search-text subtitle-1">
       ユーザーブログをもっと見る
       <v-icon class="blue--text">chevron_right</v-icon>
     </nuxt-link>


### PR DESCRIPTION
close #299 

# 概要
「グループをもっと見る」リンクのサイズ変更

# 変更点
「グループをもっと見る」リンクのサイズ変更

- 変更内容
「グループをもっと見る」リンクのサイズ変更

# スクリーンショット
元のサイズ
<img width="1404" alt="スクリーンショット 2019-12-13 14 28 14" src="https://user-images.githubusercontent.com/43775946/70771592-021d9280-1db5-11ea-827e-ee5d6693339f.png">


変更後
<img width="1404" alt="スクリーンショット 2019-12-13 14 28 01" src="https://user-images.githubusercontent.com/43775946/70771595-034ebf80-1db5-11ea-9ac8-42356f652e32.png">


# 関連issue

- [ ] #299 
