### PR TITLE
[Change] button layout (edit) <=> (save)

### DIFF
--- a/frontend/pages/auth/setting.vue
+++ b/frontend/pages/auth/setting.vue
@@ -3,12 +3,16 @@
     <h2>マイページ</h2>
 
     <v-layout class="justify-end">
-      <v-btn class="my-4" tile outlined color="success" @click="enableEdit">
-        <v-icon small>edit</v-icon>編集
-      </v-btn>
-      <v-btn class="my-4 ml-2" tile color="primary" @click="submitUserEdit">
-        <v-icon small>edit</v-icon>保存
-      </v-btn>
+      <div v-if="disabled">
+        <v-btn class="my-4" tile outlined color="success" @click="enableEdit">
+          <v-icon small>edit</v-icon>編集
+        </v-btn>
+      </div>
+      <div v-else>
+        <v-btn class="my-4 ml-2" tile color="primary" @click="submitUserEdit">
+          <v-icon small>edit</v-icon>保存
+        </v-btn>
+      </div>
     </v-layout>
     <div class="mb-5">
       <img
@@ -114,9 +118,11 @@
       :disabled="disabled"
     ></v-text-field>
     <v-layout class="justify-center">
-      <v-btn class="my-4 ml-2" tile color="primary" @click="submitUserEdit">
-        <v-icon small>edit</v-icon>保存
-      </v-btn>
+      <div v-if="!disabled">
+        <v-btn class="my-4 ml-2" tile color="primary" @click="submitUserEdit">
+          <v-icon small>edit</v-icon>保存
+        </v-btn>
+      </div>
     </v-layout>
   </div>
 </template>
@@ -344,6 +350,8 @@ export default {
         .$get('/api/auth/user')
         .then((res) => res.data)
       this.$store.dispatch('auth/setCurrentUser', { user: currentUser })
+
+      this.disabled = true
     }
   }
 }


### PR DESCRIPTION
close #304

# 概要
ユーザ情報編集画面のボタンを編集時とそれ以外で見た目を変更した

# 変更点

- ユーザ情報編集画面のボタンを編集時とそれ以外で見た目を変更した

# スクリーンショット
<img width="1404" alt="スクリーンショット 2019-12-13 17 50 00" src="https://user-images.githubusercontent.com/43775946/70786949-11aad480-1dd1-11ea-959c-c769d75ab02b.png">

# 関連issue

- [ ] #304