### PR TITLE
[Add]Information icon

### DIFF
--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -41,7 +41,7 @@ ja:
       genre:
         group_invitation: 'グループ招待'
         friend_request: '友達申請'
-        direct_message: 'ダイレクトメッセージ'
+        direct_message: 'DM'
         group_message: 'グループメッセージ'
 
   activerecord:

--- a/frontend/components/organisms/LoggedinIcons.vue
+++ b/frontend/components/organisms/LoggedinIcons.vue
@@ -13,16 +13,14 @@
       </template>
       <v-card>
         <h4 class="font-weight-thin title-position">通知</h4>
-        <div v-for="i in informations" :key="i.id">
+        <div v-for="information in limitedInformation" :key="information.id">
           <span class="font-weight-thin">
             <v-avatar class="img-small">
-              <v-img
-                src="https://icon-library.net/images/icon-muscle/icon-muscle-29.jpg"
-              />
+              <v-img :src="information.thumbnail" />
             </v-avatar>
-            {{ i.by_name }}から{{ i.genre }}が届きました。
+            {{ information.by_name }}から{{ information.genre }}が届きました。
           </span>
-          <p class="text-right">{{ i.created_at }}</p>
+          <p class="text-right">{{ information.created_at }}</p>
           <v-divider inset></v-divider>
         </div>
         <h5 class="foot-position font-weight-thin text-center">
@@ -81,6 +79,11 @@ export default {
         { link: '/auth/setting', icon: 'build', title: '設定' }
       ],
       informations: []
+    }
+  },
+  computed: {
+    limitedInformation() {
+      return this.informations.slice(0, 5)
     }
   },
   async mounted() {


### PR DESCRIPTION
close #320 

# 概要
ベルマークの中にあるユーザアイコンをつける
# 変更点
- アイコンつけた。
- 表示数を５件に制限した。

# スクリーンショット
<img width="252" alt="image" src="https://user-images.githubusercontent.com/30668284/71252228-bd22ce80-2367-11ea-8791-316e6ff0fe5a.png">

# 留意事項・参考
- リンクをまだつけてない
