### PR TITLE
Add group message

### DIFF
--- a/backend/app/channels/group_message_channel.rb
+++ b/backend/app/channels/group_message_channel.rb
@@ -10,6 +10,5 @@ class GroupMessageChannel < ApplicationCable::Channel
 
   def group_message(data)
     GroupMessage.create!(body: data['message'],user_id: current_user.id,group_id: data['groupId'])
-    #ActionCable.server.broadcast("group_#{params[:room]}",'yaaaaaaaa')
   end
 end

--- a/backend/app/channels/group_message_channel.rb
+++ b/backend/app/channels/group_message_channel.rb
@@ -1,0 +1,15 @@
+class GroupMessageChannel < ApplicationCable::Channel
+  def subscribed
+    stop_all_streams
+    stream_from "group_#{params[:room]}"
+  end
+
+  def unsubscribed
+    stop_all_streams
+  end
+
+  def group_message(data)
+    GroupMessage.create!(body: data['message'],user_id: current_user.id,group_id: data['groupId'])
+    #ActionCable.server.broadcast("group_#{params[:room]}",'yaaaaaaaa')
+  end
+end

--- a/backend/app/helpers/thumbnail_helper.rb
+++ b/backend/app/helpers/thumbnail_helper.rb
@@ -1,0 +1,11 @@
+module ThumbnailHelper
+  include Rails.application.routes.url_helpers
+
+  def make_thumbnail_url(thumbnail)
+    if thumbnail.attached?
+      url_for(thumbnail)
+    else
+      root_url + "images/noimage.png"
+    end
+  end
+end

--- a/backend/app/jobs/application_job.rb
+++ b/backend/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
 class ApplicationJob < ActiveJob::Base
+  include Rails.application.routes.url_helpers
 end

--- a/backend/app/jobs/group_messages_job.rb
+++ b/backend/app/jobs/group_messages_job.rb
@@ -1,6 +1,33 @@
 class GroupMessagesJob < ApplicationJob
+  include Rails.application.routes.url_helpers
+
   def perform(message)
-    data = SendGroupMessageSerializer.new(message).as_json
-    ActionCable.server.broadcast("group_#{message.group_id}",data)
+    begin
+      group = Group.find(message.group_id)
+      group_thumbnail = url_for(group.thumbnail)
+      user_ids = group.users.pluck(:id).map {|item| item if item != message['user_id']}.compact
+      ActiveRecord::Base.transaction do
+        user_ids.each do |user_id|
+          Information.create!(
+            genre: Information.genres[:group_message],
+            by_name: group.name,
+            link: "/groups/#{message.group_id}",
+            is_read: false,
+            user_id: user_id,
+            thumbnail: group_thumbnail
+          )
+        end
+      end
+
+      data = SendGroupMessageSerializer.new(message).as_json
+      ActionCable.server.broadcast("group_#{message.group_id}",data)
+    rescue ActiveRecord::RecordNotFound
+      ActionCable.server.broadcast("group_#{message.group_id}",'メッセージの送信に失敗しました')
+    rescue ActiveRecord::RecordInvalid
+      ActionCable.server.broadcast("group_#{message.group_id}",'メッセージの送信に失敗しました')
+    rescue => e
+      logger.error(e)
+      ActionCable.server.broadcast("group_#{message.group_id}",'メッセージの送信に失敗しました')
+    end
   end
 end

--- a/backend/app/jobs/group_messages_job.rb
+++ b/backend/app/jobs/group_messages_job.rb
@@ -1,0 +1,6 @@
+class GroupMessagesJob < ApplicationJob
+  def perform(message)
+    data = SendGroupMessageSerializer.new(message).as_json
+    ActionCable.server.broadcast("group_#{message.group_id}",data)
+  end
+end

--- a/backend/app/jobs/group_messages_job.rb
+++ b/backend/app/jobs/group_messages_job.rb
@@ -1,40 +1,26 @@
 class GroupMessagesJob < ApplicationJob
-  include Rails.application.routes.url_helpers
   include ThumbnailHelper
 
   def perform(message)
-    begin
-      group = message.group
-      group_thumbnail = make_thumbnail_url(group.thumbnail)
-      user_ids = group.users.pluck(:id).map {|item| item if item != message['user_id']}.compact
-      ActiveRecord::Base.transaction do
-        user_ids.each do |user_id|
-          Information.create!(
-            genre: Information.genres[:group_message],
-            by_name: group.name,
-            link: "/groups/#{message.group_id}",
-            is_read: false,
-            user_id: user_id,
-            thumbnail: group_thumbnail
-          )
-        end
+    group = message.group
+    group_thumbnail = make_thumbnail_url(group.thumbnail)
+    user_ids = group.users.pluck(:id).map {|item| item if item != message['user_id']}.compact
+    ActiveRecord::Base.transaction do
+      user_ids.each do |user_id|
+        Information.create!(
+          genre: Information.genres[:group_message],
+          by_name: group.name,
+          link: "/groups/#{message.group_id}",
+          is_read: false,
+          user_id: user_id,
+          thumbnail: group_thumbnail
+        )
       end
-
-      data = SendGroupMessageSerializer.new(message).as_json
-      ActionCable.server.broadcast("group_#{message.group_id}",data)
-    rescue ActiveRecord::RecordNotFound
-      ActionCable.server.broadcast("group_#{message.group_id}",'メッセージの送信に失敗しました')
-    rescue ActiveRecord::RecordInvalid
-      ActionCable.server.broadcast("group_#{message.group_id}",'メッセージの送信に失敗しました')
-    rescue => e
-      logger.error(e)
-      ActionCable.server.broadcast("group_#{message.group_id}",'メッセージの送信に失敗しました')
     end
-  end
-
-  protected
-
-  def default_url_options
-    Rails.application.config.active_job.default_url_options
+    data = SendGroupMessageSerializer.new(message).as_json
+    ActionCable.server.broadcast("group_#{message.group_id}",data)
+  rescue => e
+    logger.error(e)
+    ActionCable.server.broadcast("group_#{message.group_id}",'メッセージの送信に失敗しました')
   end
 end

--- a/backend/app/models/group_message.rb
+++ b/backend/app/models/group_message.rb
@@ -1,4 +1,6 @@
 class GroupMessage < ApplicationRecord
   belongs_to :user
   belongs_to :group
+
+  after_create_commit { GroupMessagesJob.perform_later self }
 end

--- a/backend/app/serializers/blog_serializer.rb
+++ b/backend/app/serializers/blog_serializer.rb
@@ -1,6 +1,7 @@
 class BlogSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
   include DateHelper
+  include ThumbnailHelper
 
   has_many :tags
 
@@ -14,11 +15,7 @@ class BlogSerializer < ActiveModel::Serializer
   )
 
   def thumbnail
-    if object.thumbnail.attached?
-      url_for(object.thumbnail)
-    else
-      root_url + "images/noimage.png"
-    end
+    make_thumbnail_url(object.thumbnail)
   end
 
   def created_at

--- a/backend/app/serializers/group_member_serializer.rb
+++ b/backend/app/serializers/group_member_serializer.rb
@@ -1,6 +1,7 @@
 class GroupMemberSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
   include DateHelper
+  include ThumbnailHelper
   has_many :users
 
   attributes(
@@ -15,11 +16,7 @@ class GroupMemberSerializer < ActiveModel::Serializer
   )
 
   def thumbnail
-    if object.thumbnail.attached?
-      url_for(object.thumbnail)
-    else
-      root_url + "images/noimage.png"
-    end
+    make_thumbnail_url(object.thumbnail)
   end
 
   def created_at

--- a/backend/app/serializers/group_serializer.rb
+++ b/backend/app/serializers/group_serializer.rb
@@ -1,6 +1,7 @@
 class GroupSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
   include DateHelper
+  include ThumbnailHelper
 
   attributes(
     :id,
@@ -14,11 +15,7 @@ class GroupSerializer < ActiveModel::Serializer
   )
 
   def thumbnail
-    if object.thumbnail.attached?
-      url_for(object.thumbnail)
-    else
-      root_url + "images/noimage.png"
-    end
+    make_thumbnail_url(object.thumbnail)
   end
 
   def created_at

--- a/backend/app/serializers/loggedin_user_serializer.rb
+++ b/backend/app/serializers/loggedin_user_serializer.rb
@@ -1,5 +1,6 @@
 class LoggedinUserSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
+  include ThumbnailHelper
   attributes(
     :id,
     :access_token,
@@ -33,10 +34,6 @@ class LoggedinUserSerializer < ActiveModel::Serializer
   end
 
   def thumbnail
-    if object.thumbnail.attached?
-      url_for(object.thumbnail)
-    else
-      root_url + "images/noimage.png"
-    end
+    make_thumbnail_url(object.thumbnail)
   end
 end

--- a/backend/app/serializers/send_group_message_serializer.rb
+++ b/backend/app/serializers/send_group_message_serializer.rb
@@ -1,0 +1,14 @@
+class SendGroupMessageSerializer < ActiveModel::Serializer
+  include DateHelper
+  attributes :id, :body, :user,:group_id, :created_at, :updated_at
+  belongs_to :user,key: :send_user, serializer: UserSerializer
+
+  def created_at
+    created_date(object.created_at)
+  end
+
+  def updated_at
+    updated_date(object.updated_at)
+  end
+
+end

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,5 +1,6 @@
 class UserSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
+  include ThumbnailHelper
   attributes(
     :id,
     :nickname,
@@ -18,11 +19,7 @@ class UserSerializer < ActiveModel::Serializer
   )
 
   def thumbnail
-    if object.thumbnail.attached?
-      url_for(object.thumbnail)
-    else
-      root_url + "images/noimage.png"
-    end
+    make_thumbnail_url(object.thumbnail)
   end
 
   def gender

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -60,5 +60,10 @@ module Backend
     end
 
     ActiveModelSerializers.config.adapter = :json_api
+
+    if Rails.env === 'development'
+      host = 'localhost:8080'
+      config.active_job.default_url_options = { host: host }
+    end
   end
 end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -60,10 +60,5 @@ module Backend
     end
 
     ActiveModelSerializers.config.adapter = :json_api
-
-    if Rails.env === 'development'
-      host = 'localhost:8080'
-      config.active_job.default_url_options = { host: host }
-    end
   end
 end

--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -142,6 +142,10 @@ export default {
       }
     )
   },
+  destroyed() {
+    this.directMessageChannel.unsubscribe()
+    this.$cable.disconnect()
+  },
 
   updated() {
     this.scrollToEnd()

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -189,6 +189,10 @@ export default {
 
     // this.groupMessageChannel.unsubscribe()
   },
+  destroyed() {
+    this.groupMessageChannel.unsubscribe()
+    this.$cable.disconnect()
+  },
   methods: {
     sendMessage(e) {
       // 日本語変換でもkeydownが発火してしまうため処理で制御


### PR DESCRIPTION
close #312 

# 概要

グループ内でチャットをできるようにする

# 変更点

- `group_message_channel.rb` を作成
- `group_messages_job.rb` を作成してメッセージを返す処理を追加
- `send_group_message_serializer.rb` を作成
- フロント側でメッセージを送信できるように色々追加
- `group_message_job.rb` に通知を作成する処理を追加
- ~actionjobでurl_helperを使う場合、default_url_optionsに値を設定する必要があったため`application.rb` に設定を記述~
- thumbnail helperを追加
- serializerでthumbanil helperを使うように変更

# スクリーンショット

# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
