### PR TITLE
Fix style for user blogs page

### DIFF
--- a/frontend/pages/user_blogs/index.vue
+++ b/frontend/pages/user_blogs/index.vue
@@ -76,10 +76,34 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .headline {
   line-height: 1.3rem;
   font-size: 20px !important;
   font-weight: 700;
+}
+
+.top-wrapper {
+  padding: 100px 0 100px 0;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
+    url('https://publicdomainq.net/images/201707/17s/publicdomainq-0011229ofc.jpg');
+  background-size: cover;
+  color: white;
+  font-size: 1.2em;
+  text-shadow: 0px 0px 5px #000;
+
+  h1 {
+    opacity: 0.9;
+    letter-spacing: 5px;
+  }
+  p {
+    opacity: 0.9;
+  }
+  @include smart-vertical {
+    font-size: 1em;
+    h1 {
+      font-size: 24px;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
# 概要

グローバルCSSを消した時にブログ一覧のスタイルも消えていたので追加し直し

# スクリーンショット

<img width="1680" alt="スクリーンショット 2019-12-28 3 35 09" src="https://user-images.githubusercontent.com/22770924/71528419-11f3b580-2923-11ea-8f17-60d4be04c850.png">