### PR TITLE
Move authenticatable module

### DIFF
--- a/backend/app/controllers/api/auth/oauth_controller.rb
+++ b/backend/app/controllers/api/auth/oauth_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module Auth
     class OauthController < ApplicationController
-      skip_before_action :authenticate_user_from_token!
+      skip_before_action :authenticate_user!
 
       def facebook
         callback_from(:facebook)

--- a/backend/app/controllers/api/blogs_controller.rb
+++ b/backend/app/controllers/api/blogs_controller.rb
@@ -1,5 +1,5 @@
 class Api::BlogsController < ApplicationController
-    skip_before_action :authenticate_user_from_token!, only: [:index, :show]
+    skip_before_action :authenticate_user!, only: [:index, :show]
 
     #すべてのブログの一覧を返すアクション
     def index

--- a/backend/app/controllers/api/debug_controller.rb
+++ b/backend/app/controllers/api/debug_controller.rb
@@ -1,5 +1,5 @@
 class Api::DebugController < ApplicationController
-  skip_before_action :authenticate_user_from_token!, only: [:index]
+  skip_before_action :authenticate_user!, only: [:index]
 
   def index
     if Rails.env === 'production'

--- a/backend/app/controllers/api/group_members_controller.rb
+++ b/backend/app/controllers/api/group_members_controller.rb
@@ -1,5 +1,5 @@
 class Api::GroupMembersController < ApplicationController
-  skip_before_action :authenticate_user_from_token!, only: [:show]
+  skip_before_action :authenticate_user!, only: [:show]
 
   def show
     begin

--- a/backend/app/controllers/api/groups_controller.rb
+++ b/backend/app/controllers/api/groups_controller.rb
@@ -1,5 +1,5 @@
 class Api::GroupsController < ApplicationController
-  skip_before_action :authenticate_user_from_token!, only: [:index, :show]
+  skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
     @groups = ActiveModel::Serializer::CollectionSerializer.new(

--- a/backend/app/controllers/api/tags_controller.rb
+++ b/backend/app/controllers/api/tags_controller.rb
@@ -1,5 +1,5 @@
 class Api::TagsController < ApplicationController
-  skip_before_action :authenticate_user_from_token!, only: [:index]
+  skip_before_action :authenticate_user!, only: [:index]
 
   #Tagすべての一覧を返すアクション
   def index

--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class UsersController < ApplicationController
-    skip_before_action :authenticate_user_from_token!, only: [:index, :show]
+    skip_before_action :authenticate_user!, only: [:index, :show]
 
     def index
       search_result_data = User.search_user_in(search_params)

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::API
+  include Authenticatable
+
   before_action :authenticate_user_from_token!
 
   # トークン生成済みのユーザーのみ認証する
@@ -9,33 +11,6 @@ class ApplicationController < ActionController::API
     else
       error_res(401, message: '認証失敗しました')
     end
-  end
-
-  def authenticate_user_from_token
-    token = request.headers['Authorization']
-    # TODO: 今後、トークンの失効期限をもうけたい場合、トークン生成時を記録し、以下のユーザー取得時に時間の比較をする
-    user = User.find_by(access_token: token)
-
-    if user && user.secure_token_compare(token)
-      user
-    else
-      nil
-    end
-  end
-
-  # ログイン用のトークンを生成し、サインインし、ログインしたユーザーを返す
-  def authenticate(user)
-    user.update_access_token!
-    @current_user = user
-  end
-
-  def sign_in?
-    !!@current_user
-  end
-
-  # ログイン中のユーザーを返す
-  def current_user
-    @current_user ||= authenticate_user_from_token
   end
 
   def success_res(status, message: nil, data: nil, meta: nil)

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,14 +1,13 @@
 class ApplicationController < ActionController::API
   include Authenticatable
 
-  before_action :authenticate_user_from_token!
+  before_action :authenticate_user!
 
   # トークン生成済みのユーザーのみ認証する
-  def authenticate_user_from_token!
-    user = authenticate_user_from_token
-    if user
-      @current_user = user
-    else
+  def authenticate_user!
+    begin
+      authenticate_user_from_token!
+    rescue Exceptions::AuthenticationError
       error_res(401, message: '認証失敗しました')
     end
   end

--- a/backend/app/controllers/concerns/authenticatable.rb
+++ b/backend/app/controllers/concerns/authenticatable.rb
@@ -1,0 +1,30 @@
+module Authenticatable
+  extend ActiveSupport::Concern
+
+  def authenticate_user_from_token
+    token = request.headers['Authorization']
+    # TODO: 今後、トークンの失効期限をもうけたい場合、トークン生成時を記録し、以下のユーザー取得時に時間の比較をする
+    user = User.find_by(access_token: token)
+
+    if user && user.secure_token_compare(token)
+      user
+    else
+      nil
+    end
+  end
+
+  # ログイン用のトークンを生成し、サインインし、ログインしたユーザーを返す
+  def authenticate(user)
+    user.update_access_token!
+    @current_user = user
+  end
+
+  def sign_in?
+    !!@current_user
+  end
+
+  # ログイン中のユーザーを返す
+  def current_user
+    @current_user ||= authenticate_user_from_token
+  end
+end

--- a/backend/app/controllers/concerns/authenticatable.rb
+++ b/backend/app/controllers/concerns/authenticatable.rb
@@ -1,6 +1,16 @@
 module Authenticatable
   extend ActiveSupport::Concern
 
+  # トークン生成済みのユーザーのみ認証する
+  def authenticate_user_from_token!
+    user = authenticate_user_from_token
+    if user
+      @current_user = user
+    else
+      raise Exceptions::AuthenticationError
+    end
+  end
+
   def authenticate_user_from_token
     token = request.headers['Authorization']
     # TODO: 今後、トークンの失効期限をもうけたい場合、トークン生成時を記録し、以下のユーザー取得時に時間の比較をする

--- a/backend/app/controllers/mock/blogs_controller.rb
+++ b/backend/app/controllers/mock/blogs_controller.rb
@@ -1,6 +1,6 @@
 module Mock
   class BlogsController < ApplicationController
-    skip_before_action :authenticate_user_from_token!, only: [:index, :show]
+    skip_before_action :authenticate_user!, only: [:index, :show]
 
     def index
       names = %w(

--- a/backend/app/controllers/mock/group_messages_controller.rb
+++ b/backend/app/controllers/mock/group_messages_controller.rb
@@ -1,6 +1,6 @@
 module Mock
   class GroupMessagesController < ApplicationController
-    skip_before_action :authenticate_user_from_token!, only: [:show]
+    skip_before_action :authenticate_user!, only: [:show]
 
     def show
       users = User.all.limit(4).to_a

--- a/backend/app/controllers/mock/groups_controller.rb
+++ b/backend/app/controllers/mock/groups_controller.rb
@@ -1,6 +1,6 @@
 module Mock
   class GroupsController < ApplicationController
-    skip_before_action :authenticate_user_from_token!, only: [:index, :show]
+    skip_before_action :authenticate_user!, only: [:index, :show]
 
     def index
       data = []

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -60,5 +60,7 @@ module Backend
     end
 
     ActiveModelSerializers.config.adapter = :json_api
+
+    config.autoload_paths += Dir["#{config.root}/lib/**/"]
   end
 end

--- a/backend/lib/exceptions.rb
+++ b/backend/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class AuthenticationError < StandardError; end
+end


### PR DESCRIPTION
# 概要

コントローラーの認証処理をモジュールに移行

# 変更点

- コントローラーの認証処理をモジュールに移行
- AuthenticationError(認証失敗時の独自エラー)を定義
- `lib/`をオートロードに登録
- ログイン要求メソッド名を変更
