### PR TITLE
Add group thumbnail

### DIFF
--- a/frontend/pages/TheInformation.vue
+++ b/frontend/pages/TheInformation.vue
@@ -23,7 +23,7 @@
 export default {
   props: {
     notification: {
-      type: Object,
+      type: Array,
       default: null
     }
   }

--- a/frontend/pages/TheJoingroup.vue
+++ b/frontend/pages/TheJoingroup.vue
@@ -26,7 +26,7 @@
 export default {
   props: {
     groups: {
-      type: Object,
+      type: Array,
       default: null
     }
   }

--- a/frontend/pages/TheRecommenduser.vue
+++ b/frontend/pages/TheRecommenduser.vue
@@ -25,7 +25,7 @@
 export default {
   props: {
     recommends: {
-      type: Object,
+      type: Array,
       default: null
     }
   }

--- a/frontend/pages/groups/_id/index.vue
+++ b/frontend/pages/groups/_id/index.vue
@@ -5,6 +5,11 @@
       戻る
     </v-btn>
     <p class="grey--text text--lighten-1">{{ group.created_at }}作成</p>
+    <v-img
+      :src="group.thumbnail"
+      class="group-thumbnail d-inline-block"
+      contain
+    ></v-img>
     <v-flex>
       <h1>「{{ group.name }}」グループ</h1>
       <div v-if="!group.is_public"><v-icon>lock</v-icon></div>
@@ -215,6 +220,11 @@ export default {
 </script>
 
 <style>
+.group-thumbnail {
+  min-height: 200px;
+  max-height: 400px;
+}
+
 .theme--light.v-btn--active::before {
   opacity: 0;
 }


### PR DESCRIPTION
# 概要

グループサムネを追加。
スタイルはUIレビューで教えてもらう予定のため適当

# スクリーンショット
<img width="1680" alt="スクリーンショット 2019-12-31 16 48 04" src="https://user-images.githubusercontent.com/22770924/71614135-5fa34300-2bed-11ea-9f3f-a3887f401e9f.png">
<img width="374" alt="スクリーンショット 2019-12-31 16 47 56" src="https://user-images.githubusercontent.com/22770924/71614136-5fa34300-2bed-11ea-9620-82af627f0608.png">
