### PR TITLE
ヘッダー通知ウィンドウのデザイン修正

### DIFF
--- a/frontend/components/organisms/LoggedinIcons.vue
+++ b/frontend/components/organisms/LoggedinIcons.vue
@@ -12,7 +12,7 @@
         </v-btn>
       </template>
       <v-card>
-        <h4 class="font-weight-thin title-position">通知</h4>
+        <h5 class="font-weight-thin title-position">通知</h5>
         <div
           v-for="information in limitedInformation"
           :key="information.id"
@@ -130,7 +130,7 @@ export default {
   margin-bottom: 5px;
   padding: 10.8px 10px;
 }
-.title-position h4 {
+.title-position h5 {
   font-size: 15px;
 }
 .foot-position {

--- a/frontend/components/organisms/LoggedinIcons.vue
+++ b/frontend/components/organisms/LoggedinIcons.vue
@@ -128,12 +128,15 @@ export default {
 .title-position {
   background-color: #ededed;
   margin-bottom: 5px;
-  padding: 5px 10px;
+  padding: 10.8px 10px;
+}
+.title-position h4 {
+  font-size: 15px;
 }
 .foot-position {
   background-color: #ededed;
   margin-top: 5px;
-  padding: 8px 0;
+  padding: 10.8px 0;
 }
 .foot-position h5 {
   font-size: 15px;

--- a/frontend/components/organisms/LoggedinIcons.vue
+++ b/frontend/components/organisms/LoggedinIcons.vue
@@ -13,7 +13,11 @@
       </template>
       <v-card>
         <h4 class="font-weight-thin title-position">通知</h4>
-        <div v-for="information in limitedInformation" :key="information.id">
+        <div
+          v-for="information in limitedInformation"
+          :key="information.id"
+          class="contents-item"
+        >
           <span class="font-weight-thin">
             <v-avatar class="img-small">
               <v-img :src="information.thumbnail" />
@@ -124,9 +128,17 @@ export default {
 .title-position {
   background-color: #ededed;
   margin-bottom: 5px;
+  padding: 5px 10px;
 }
 .foot-position {
   background-color: #ededed;
   margin-top: 5px;
+  padding: 8px 0;
+}
+.foot-position h5 {
+  font-size: 15px;
+}
+.contents-item {
+  padding: 3px 14px;
 }
 </style>

--- a/frontend/components/organisms/LoggedinIcons.vue
+++ b/frontend/components/organisms/LoggedinIcons.vue
@@ -16,7 +16,7 @@
         <div
           v-for="information in limitedInformation"
           :key="information.id"
-          class="contents-item"
+          class="content-items"
         >
           <span class="font-weight-thin">
             <v-avatar class="img-small">
@@ -114,21 +114,15 @@ export default {
   margin: 0px 10px 0px 0px;
   vertical-align: middle;
 }
-.text-position {
-  margin: 5px 0px;
-}
 .img-small {
   width: 30px;
   height: 30px;
-}
-.card-size {
-  width: 150%;
-  height: 150%;
 }
 .title-position {
   background-color: #ededed;
   margin-bottom: 5px;
   padding: 10.8px 10px;
+  margin: 5px 0px;
 }
 .title-position h5 {
   font-size: 15px;
@@ -141,7 +135,7 @@ export default {
 .foot-position h5 {
   font-size: 15px;
 }
-.contents-item {
+.content-items {
   padding: 3px 14px;
 }
 </style>


### PR DESCRIPTION
close #346 

# 概要
全体的に、余白が全然なかったので見辛い。
操作ミスを起こす可能性があった

# 変更点

- 「通知」と「通知一覧を見る」の上下に余白を追加
- 通知内のアイテム一つ一つに余白を追加

# スクリーンショット
![image](https://user-images.githubusercontent.com/30668284/72127882-5156e300-33b4-11ea-944e-e80e58b7c521.png)

