### PR TITLE
[change]link color

### DIFF
--- a/frontend/components/organisms/FriendRequestBtn.vue
+++ b/frontend/components/organisms/FriendRequestBtn.vue
@@ -42,17 +42,17 @@ export default {
     }
   },
 
-  computed: {
-    isFriends() {
-      return this.user ? this.user.is_friends : false
-    }
-  },
-
   data: () => ({
     requestFriend: false,
     resultRequestType: null,
     resultRequestMessage: null
   }),
+
+  computed: {
+    isFriends() {
+      return this.user ? this.user.is_friends : false
+    }
+  },
 
   methods: {
     async sendFriendRequest() {

--- a/frontend/components/organisms/GroupJoinBtn.vue
+++ b/frontend/components/organisms/GroupJoinBtn.vue
@@ -37,17 +37,17 @@ export default {
     }
   },
 
-  computed: {
-    isGroupJoined() {
-      return this.group ? this.group.joined : false
-    }
-  },
-
   data: () => ({
     join: false,
     resultJoinType: null,
     resultJoinMessage: null
   }),
+
+  computed: {
+    isGroupJoined() {
+      return this.group ? this.group.joined : false
+    }
+  },
 
   methods: {
     async requestGroupJoin(group) {

--- a/frontend/components/organisms/InDevelopmentCard.vue
+++ b/frontend/components/organisms/InDevelopmentCard.vue
@@ -7,10 +7,16 @@
       今しばらくお待ちください。
     </v-card-text>
     <v-card-actions class="justify-center">
-      <v-btn text color="primary" to="/home">ホームページに戻る</v-btn>
-      <v-btn text color="primary" @click="() => $router.go(-1)">
+      <v-btn text class="return-btn" to="/home">ホームページに戻る</v-btn>
+      <v-btn text class="return-btn" @click="() => $router.go(-1)">
         一つ前のページに戻る
       </v-btn>
     </v-card-actions>
   </v-card>
 </template>
+
+<style lang="scss" scoped>
+.return-btn {
+  color: $main-color-deep;
+}
+</style>

--- a/frontend/layouts/TheFooter.vue
+++ b/frontend/layouts/TheFooter.vue
@@ -22,3 +22,10 @@
     </v-footer>
   </div>
 </template>
+
+<style lang="scss" scoped>
+a {
+  color: $main-color-deep;
+  text-decoration: none;
+}
+</style>


### PR DESCRIPTION
close #351 

# 概要

リンクの色をオレンジ色に変更する

# 変更点

- リンクの色をオレンジ色に変更

# スクリーンショット
<img width="1432" alt="スクリーンショット 2020-01-14 11 29 41" src="https://user-images.githubusercontent.com/44107494/72309130-76539a80-36c1-11ea-9c68-6c4fc18077aa.png">

# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
