### PR TITLE
[fix]LP design

### DIFF
--- a/frontend/assets/scss/lp.scss
+++ b/frontend/assets/scss/lp.scss
@@ -9,7 +9,7 @@
     url('https://yumiid.com/wp-content/uploads/2018/03/%E7%AD%8B%E3%83%88%E3%83%AC%E3%81%8C%E7%94%B7%E5%A5%B3%E9%96%A2%E4%BF%82%E3%81%AB%E4%B8%8E%E3%81%88%E3%82%8B%E3%83%A1%E3%83%AA%E3%83%83%E3%83%88-%E3%81%8A%E4%BA%92%E3%81%84%E5%88%87%E7%A3%8B%E7%90%A2%E7%A3%A8%E3%81%A7%E3%81%8D%E3%82%8B.png');
   background-size: cover;
   color: white;
-  font-size: 2.2em;
+  font-size: 1.6em;
   text-shadow: 0px 0px 5px #000;
 
   h1 {
@@ -31,7 +31,7 @@
   }
 
   @media screen and (min-width: 480px) and (max-width: 628px) {
-    font-size: 1.3em;
+    font-size: 1.1em;
     h1 {
       font-size: 36px;
     }
@@ -42,7 +42,7 @@
   }
 
   @media screen and (min-width: 629px) and (max-width: 959px) {
-    font-size: 1.6em;
+    font-size: 1.3em;
     h1 {
       font-size: 52px;
     }
@@ -55,6 +55,8 @@
   .register-wrapper {
     text-align: left;
     a.register-btn {
+      padding: 25px 60px;
+      font-size: 1.5rem;
       background: $trans-main-color !important;
     }
   }

--- a/frontend/assets/scss/lp.scss
+++ b/frontend/assets/scss/lp.scss
@@ -1,11 +1,15 @@
 @charset "UTF-8";
+.v-application p {
+  margin-bottom: 0;
+}
 .top-wrapper {
+  height: 88vh;
   padding: 100px 0 100px 0;
   background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
-    url('https://publicdomainq.net/images/201707/17s/publicdomainq-0011229ofc.jpg');
+    url('https://yumiid.com/wp-content/uploads/2018/03/%E7%AD%8B%E3%83%88%E3%83%AC%E3%81%8C%E7%94%B7%E5%A5%B3%E9%96%A2%E4%BF%82%E3%81%AB%E4%B8%8E%E3%81%88%E3%82%8B%E3%83%A1%E3%83%AA%E3%83%83%E3%83%88-%E3%81%8A%E4%BA%92%E3%81%84%E5%88%87%E7%A3%8B%E7%90%A2%E7%A3%A8%E3%81%A7%E3%81%8D%E3%82%8B.png');
   background-size: cover;
   color: white;
-  font-size: 1.2em;
+  font-size: 2.2em;
   text-shadow: 0px 0px 5px #000;
 
   h1 {
@@ -19,6 +23,32 @@
     font-size: 1em;
     h1 {
       font-size: 24px;
+    }
+
+    p {
+      width: 65vw;
+    }
+  }
+
+  @media screen and (min-width: 480px) and (max-width: 628px) {
+    font-size: 1.3em;
+    h1 {
+      font-size: 36px;
+    }
+
+    p {
+      width: 80vw;
+    }
+  }
+
+  @media screen and (min-width: 629px) and (max-width: 959px) {
+    font-size: 1.6em;
+    h1 {
+      font-size: 52px;
+    }
+
+    p {
+      width: 84vw;
     }
   }
 
@@ -35,7 +65,6 @@
   text-align: center;
 
   .service-heading h2 {
-    padding-top: 50px;
     padding-bottom: 50px;
     color: #5f5d60;
   }
@@ -50,7 +79,7 @@
     width: 50%; // 1/2 size
   }
   @include normal-pc {
-    width: 16.66%; // 1/6 size
+    width: 33%; // 1/6 size
   }
 
   .service-icon {
@@ -73,16 +102,24 @@
     @include normal-pc {
       width: 80%;
     }
+
+    @media screen and (min-width: 480px) and (max-width: 628px) {
+      font-size: 0.7em;
+    }  
   }
 }
 
 .register-wrapper {
   text-align: center;
   a.register-btn {
-    font-size: 1.4rem;
+    font-size: 1.9rem;
     text-transform: none;
     padding: 24px 12px;
     @include smart-vertical {
+      width: 100%;
+    }
+
+    @media screen and (min-width: 480px) and (max-width: 628px) {
       width: 100%;
     }
   }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -2,9 +2,14 @@
   <div>
     <div class="top-wrapper">
       <div class="container">
-        <h1>筋肉を今よりも素敵に。</h1>
-        <p>筋肉大好き人間が集まるマッチングアプリです。</p>
-        <p>他人が投稿した筋肉を見たり、筋トレをしましょう。</p>
+        <h1>筋トレであなたの</h1>
+        <h1>人生を笑顔に</h1>
+        <p>
+          筋トレ初心者から上級者の方までご利用できるマッチングアプリです。
+        </p>
+        <p>
+          Muscler'sで友達を作り筋トレライフを充実させましょう！！
+        </p>
         <div class="register-wrapper mt-5">
           <v-btn to="/auth/login" class="register-btn" dark nuxt>
             Muscler'sを始める
@@ -20,7 +25,7 @@
         <div class="services">
           <div class="service-box">
             <div class="service-icon">
-              <v-icon size="90">emoji_people</v-icon>
+              <v-icon size="120">emoji_people</v-icon>
               <p>マッチング</p>
             </div>
             <p class="service-text">
@@ -29,7 +34,7 @@
           </div>
           <div class="service-box">
             <div class="service-icon">
-              <v-icon size="90">person_add</v-icon>
+              <v-icon size="120">person_add</v-icon>
               <p>友達申請</p>
             </div>
             <p class="service-text">
@@ -38,7 +43,7 @@
           </div>
           <div class="service-box">
             <div class="service-icon">
-              <v-icon size="90">message</v-icon>
+              <v-icon size="120">message</v-icon>
               <p>メッセージ</p>
             </div>
             <p class="service-text">
@@ -47,7 +52,7 @@
           </div>
           <div class="service-box">
             <div class="service-icon">
-              <v-icon size="90">search</v-icon>
+              <v-icon size="120">search</v-icon>
               <p>検索</p>
             </div>
             <p class="service-text">
@@ -56,7 +61,7 @@
           </div>
           <div class="service-box">
             <div class="service-icon">
-              <v-icon size="90">group</v-icon>
+              <v-icon size="120">group</v-icon>
               <p>グループ</p>
             </div>
             <p class="service-text">
@@ -65,7 +70,7 @@
           </div>
           <div class="service-box">
             <div class="service-icon">
-              <v-icon size="90">fitness_center</v-icon>
+              <v-icon size="120">fitness_center</v-icon>
               <p>筋肉</p>
             </div>
             <p class="service-text">


### PR DESCRIPTION
close #353 

# 概要

LPのデザインの変更

# 変更点

- キャッチフレーズの変更
- レスポンシブ対応
- ボタンサイズの変更
- topのfont-sizeを変更

# スクリーンショット
PC
<img width="1440" alt="スクリーンショット 2020-01-15 13 43 15" src="https://user-images.githubusercontent.com/44107494/72405668-0581b080-379d-11ea-8687-f0bf36395fa5.png">
<img width="1440" alt="スクリーンショット 2020-01-15 13 43 22" src="https://user-images.githubusercontent.com/44107494/72405669-0581b080-379d-11ea-9c6c-82e65c1d3aa1.png">


スマホ
<img width="364" alt="スクリーンショット 2020-01-15 13 44 19" src="https://user-images.githubusercontent.com/44107494/72405710-2f3ad780-379d-11ea-9160-cc3c5c6fd002.png">
<img width="363" alt="スクリーンショット 2020-01-15 13 44 28" src="https://user-images.githubusercontent.com/44107494/72405714-3235c800-379d-11ea-99a0-f3b8cd98e9ba.png">



# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
