### PR TITLE
Fix dm scroll bug

### DIFF
--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -17,7 +17,7 @@
     </v-snackbar>
 
     <v-card max-width="450" class="mx-auto chat-card">
-      <div class="overflow-y-auto messages">
+      <div id="message-box" class="overflow-y-auto messages">
         <template v-for="(item, index) in directMessages">
           <v-list :id="`message-${index}`" :key="index" three-line class="pa-0">
             <v-list-item>
@@ -160,12 +160,12 @@ export default {
       return this.directMessageGroup.by_user
     },
     scrollToEnd() {
-      const chatLog = document.getElementById(
-        `message-${this.directMessages.length - 1}`
-      )
-      if (!chatLog) return
-      // TODO: これではoverflow:scroll表示されている要素に飛べないっぽい
-      chatLog.scrollTop = chatLog.scrollHeight
+      this.$nextTick(() => {
+        const chatLog = document.getElementById('message-box')
+        if (!chatLog) return
+        // TODO: これではoverflow:scroll表示されている要素に飛べないっぽい
+        chatLog.scrollTop = chatLog.scrollHeight
+      })
     },
     sendMessage(e) {
       // 日本語変換でもkeydownが発火してしまうため処理で制御

--- a/frontend/pages/direct_messages/_id.vue
+++ b/frontend/pages/direct_messages/_id.vue
@@ -163,7 +163,6 @@ export default {
       this.$nextTick(() => {
         const chatLog = document.getElementById('message-box')
         if (!chatLog) return
-        // TODO: これではoverflow:scroll表示されている要素に飛べないっぽい
         chatLog.scrollTop = chatLog.scrollHeight
       })
     },


### PR DESCRIPTION
close #300 

# 概要

メッセージを入力した時にスクロールが一番下まで移動しないバグの修正

# 変更点

- タグにIdを追加

# スクリーンショット
<img width="724" alt="スクリーンショット 2020-01-16 12 07 59" src="https://user-images.githubusercontent.com/44107494/72489941-0ed05300-3859-11ea-8034-ec585a97755f.png">


# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
