### PR TITLE
Add response group page

### DIFF
--- a/frontend/assets/scss/group.scss
+++ b/frontend/assets/scss/group.scss
@@ -30,22 +30,67 @@
   }
 }
 
-@media screen and (max-width: 599px){
+@include smart-vertical {
   .group-card {
-    max-width: 137px;
-    max-height: 300px;
+    max-width: 100vw;
+    max-height: 550px;
     min-height: 150px;
   
     > .group-image {
-      height: 100px;
+      height: 250px;
     }
     > .group-name {
       font-size: 1.1rem;
     }
   }  
-}  
+}
 
-@media screen and (min-width: 600px){
+@include smart-horizontal {
+  .group-card {
+    max-width: 100vw;
+    max-height: 550px;
+    min-height: 150px;
+  
+    > .group-image {
+      height: 250px;
+    }
+    > .group-name {
+      font-size: 1.1rem;
+    }
+  }  
+}
+
+@include tablet {
+  .group-card {
+    max-width: 50vw;
+    max-height: 550px;
+    min-height: 450px;
+
+    > .group-image {
+      height: 200px;
+    }
+    > .group-name {
+      font-size: 1.1rem;
+    }
+  }
+}
+
+@include small-pc {
+  .group-card {
+    max-width: 33vw;
+    max-height: 550px;
+    min-height: 450px;
+
+    > .group-image {
+      height: 200px;
+    }
+    > .group-name {
+      font-size: 1.1rem;
+    }
+  }
+}
+
+@include normal-pc {
   .group-card {
     max-width: 374px;
     max-height: 550px;
@@ -59,6 +104,7 @@
     }
   }
 }
+
 .group-card:hover {
   > .group-name {
     color: $main-color;

--- a/frontend/assets/scss/group.scss
+++ b/frontend/assets/scss/group.scss
@@ -1,0 +1,66 @@
+.card-body-overflow {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  min-height: 5em;
+}
+.sub-info-text {
+  font-size: 14px;
+}
+
+.group-page-header {
+  display: flex;
+}
+
+.group-search-form {
+  display: flex;
+  align-items: center;
+
+  > .v-input--is-focused.search-box {
+    color: $main-color-deep !important;
+    caret-color: $main-color-deep !important;
+  }
+
+  > .search-text {
+    font-weight: bold;
+    font-size: 77%;
+    text-decoration: none;
+    color: $main-color-deep;
+  }
+}
+
+@media screen and (max-width: 599px){
+  .group-card {
+    max-width: 137px;
+    max-height: 300px;
+    min-height: 150px;
+  
+    > .group-image {
+      height: 100px;
+    }
+    > .group-name {
+      font-size: 1.1rem;
+    }
+  }  
+}  
+
+@media screen and (min-width: 600px){
+  .group-card {
+    max-width: 374px;
+    max-height: 550px;
+    min-height: 450px;
+
+    > .group-image {
+      height: 200px;
+    }
+    > .group-name {
+      font-size: 1.1rem;
+    }
+  }
+}
+.group-card:hover {
+  > .group-name {
+    color: $main-color;
+  }
+}

--- a/frontend/assets/scss/group.scss
+++ b/frontend/assets/scss/group.scss
@@ -30,6 +30,19 @@
   }
 }
 
+.group-card {
+  max-width: 374px;
+  max-height: 550px;
+  min-height: 450px;
+
+  > .group-image {
+    height: 200px;
+  }
+  > .group-name {
+    font-size: 1.1rem;
+  }
+}
+
 @include smart-vertical {
   .group-card {
     max-width: 100vw;
@@ -78,21 +91,6 @@
 @include small-pc {
   .group-card {
     max-width: 33vw;
-    max-height: 550px;
-    min-height: 450px;
-
-    > .group-image {
-      height: 200px;
-    }
-    > .group-name {
-      font-size: 1.1rem;
-    }
-  }
-}
-
-@include normal-pc {
-  .group-card {
-    max-width: 374px;
     max-height: 550px;
     min-height: 450px;
 

--- a/frontend/assets/scss/group.scss
+++ b/frontend/assets/scss/group.scss
@@ -52,9 +52,6 @@
     > .group-image {
       height: 250px;
     }
-    > .group-name {
-      font-size: 1.1rem;
-    }
   }  
 }
 
@@ -67,9 +64,6 @@
     > .group-image {
       height: 250px;
     }
-    > .group-name {
-      font-size: 1.1rem;
-    }
   }  
 }
 
@@ -78,13 +72,6 @@
     max-width: 50vw;
     max-height: 550px;
     min-height: 450px;
-
-    > .group-image {
-      height: 200px;
-    }
-    > .group-name {
-      font-size: 1.1rem;
-    }
   }
 }
 
@@ -93,13 +80,6 @@
     max-width: 33vw;
     max-height: 550px;
     min-height: 450px;
-
-    > .group-image {
-      height: 200px;
-    }
-    > .group-name {
-      font-size: 1.1rem;
-    }
   }
 }
 

--- a/frontend/pages/groups/index.vue
+++ b/frontend/pages/groups/index.vue
@@ -46,8 +46,8 @@
           cols="12"
           xl="3"
           lg="3"
-          md="3"
-          sm="3"
+          md="4"
+          sm="6"
         >
           <nuxt-link
             :to="{ name: 'groups-id', params: { id: group.id } }"

--- a/frontend/pages/groups/index.vue
+++ b/frontend/pages/groups/index.vue
@@ -146,53 +146,5 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.card-body-overflow {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
-  min-height: 5em;
-}
-.sub-info-text {
-  font-size: 14px;
-}
-
-.group-page-header {
-  display: flex;
-}
-
-.group-search-form {
-  display: flex;
-  align-items: center;
-
-  > .v-input--is-focused.search-box {
-    color: $main-color-deep !important;
-    caret-color: $main-color-deep !important;
-  }
-
-  > .search-text {
-    font-weight: bold;
-    font-size: 77%;
-    text-decoration: none;
-    color: $main-color-deep;
-  }
-}
-
-.group-card {
-  max-width: 374px;
-  max-height: 550px;
-  min-height: 450px;
-
-  > .group-image {
-    height: 200px;
-  }
-  > .group-name {
-    font-size: 1.1rem;
-  }
-}
-.group-card:hover {
-  > .group-name {
-    color: $main-color;
-  }
-}
+@import '~/assets/scss/group.scss';
 </style>


### PR DESCRIPTION
close #360 

# 概要

グループ画面をレスポンシブ対応させる

# 変更点

- 画面サイズごとにCSSを記述

# スクリーンショット
width size ~599px
<img width="377" alt="スクリーンショット 2020-01-21 10 19 10" src="https://user-images.githubusercontent.com/44107494/72767501-7b6f9700-3c37-11ea-80dc-02978013e341.png">
width size 560px ~ 959px
<img width="944" alt="スクリーンショット 2020-01-21 10 20 05" src="https://user-images.githubusercontent.com/44107494/72767547-9c37ec80-3c37-11ea-9b65-61e441a4bda2.png">
width size 960px ~ 1279px
<img width="925" alt="スクリーンショット 2020-01-21 10 22 08" src="https://user-images.githubusercontent.com/44107494/72767601-e5883c00-3c37-11ea-9513-4860f2622c4e.png">
width size 1280px ~
<img width="898" alt="スクリーンショット 2020-01-21 10 23 12" src="https://user-images.githubusercontent.com/44107494/72767652-0baddc00-3c38-11ea-91c6-2888172075ad.png">


# 関連issue

- [ ] あればissue番号を

# 留意事項・参考

留意事項や参考があれば
